### PR TITLE
Fix recreation of Steam shortcuts

### DIFF
--- a/NonSteamLaunchers.sh
+++ b/NonSteamLaunchers.sh
@@ -2344,8 +2344,8 @@ if epicshortcutdirectory != '':
         # Create a new entry for the Steam shortcut
         new_entry = {
             'appid': f'{str(epicappid)}',
-            'AppName': 'Epic Games',
-            'Exe': '$epicshortcutdirectory',
+            'appname': 'Epic Games',
+            'exe': '$epicshortcutdirectory',
             'StartDir': '$epicshortcutdirectory',
             'icon': '',
             'ShortcutPath': '',
@@ -2366,18 +2366,18 @@ if epicshortcutdirectory != '':
         entry_exists = False
         if type(shortcuts['shortcuts']) == list:
             for entry in shortcuts['shortcuts']:
-                entry.setdefault('AppName', '')
-                entry.setdefault('Exe', '')
-                if entry['AppName'] == new_entry['AppName'] and entry['Exe'] == new_entry['Exe']:
+                entry.setdefault('appname', '')
+                entry.setdefault('exe', '')
+                if entry['appname'] == new_entry['appname'] and entry['exe'] == new_entry['exe']:
                     entry_exists = True
                     break
             if not entry_exists:
                 shortcuts['shortcuts'].append(new_entry)
         elif type(shortcuts['shortcuts']) == dict:
             for key in shortcuts['shortcuts'].keys():
-                shortcuts['shortcuts'][key].setdefault('AppName', '')
-                shortcuts['shortcuts'][key].setdefault('Exe', '')
-                if shortcuts['shortcuts'][key]['AppName'] == new_entry['AppName'] and shortcuts['shortcuts'][key]['Exe'] == new_entry['Exe']:
+                shortcuts['shortcuts'][key].setdefault('appname', '')
+                shortcuts['shortcuts'][key].setdefault('exe', '')
+                if shortcuts['shortcuts'][key]['appname'] == new_entry['appname'] and shortcuts['shortcuts'][key]['exe'] == new_entry['exe']:
                     entry_exists = True
                     break
             if not entry_exists:
@@ -2403,8 +2403,8 @@ if gogshortcutdirectory != '':
         # Create a new entry for the Steam shortcut
         new_entry = {
             'appid': f'{str(gogappid)}',
-            'AppName': 'Gog Galaxy',
-            'Exe': '$gogshortcutdirectory',
+            'appname': 'Gog Galaxy',
+            'exe': '$gogshortcutdirectory',
             'StartDir': '$gogshortcutdirectory',
             'icon': '',
             'ShortcutPath': '',
@@ -2425,18 +2425,18 @@ if gogshortcutdirectory != '':
         entry_exists = False
         if type(shortcuts['shortcuts']) == list:
             for entry in shortcuts['shortcuts']:
-                entry.setdefault('AppName', '')
-                entry.setdefault('Exe', '')
-                if entry['AppName'] == new_entry['AppName'] and entry['Exe'] == new_entry['Exe']:
+                entry.setdefault('appname', '')
+                entry.setdefault('exe', '')
+                if entry['appname'] == new_entry['appname'] and entry['exe'] == new_entry['exe']:
                     entry_exists = True
                     break
             if not entry_exists:
                 shortcuts['shortcuts'].append(new_entry)
         elif type(shortcuts['shortcuts']) == dict:
             for key in shortcuts['shortcuts'].keys():
-                shortcuts['shortcuts'][key].setdefault('AppName', '')
-                shortcuts['shortcuts'][key].setdefault('Exe', '')
-                if shortcuts['shortcuts'][key]['AppName'] == new_entry['AppName'] and shortcuts['shortcuts'][key]['Exe'] == new_entry['Exe']:
+                shortcuts['shortcuts'][key].setdefault('appname', '')
+                shortcuts['shortcuts'][key].setdefault('exe', '')
+                if shortcuts['shortcuts'][key]['appname'] == new_entry['appname'] and shortcuts['shortcuts'][key]['exe'] == new_entry['exe']:
                     entry_exists = True
                     break
             if not entry_exists:
@@ -2466,8 +2466,8 @@ if uplayshortcutdirectory != '':
         # Create a new entry for the Steam shortcut
         new_entry = {
             'appid': f'{str(ubisoftappid)}',
-            'AppName': 'Ubisoft Connect',
-            'Exe': '$uplayshortcutdirectory',
+            'appname': 'Ubisoft Connect',
+            'exe': '$uplayshortcutdirectory',
             'StartDir': '$uplayshortcutdirectory',
             'icon': '',
             'ShortcutPath': '',
@@ -2488,18 +2488,18 @@ if uplayshortcutdirectory != '':
         entry_exists = False
         if type(shortcuts['shortcuts']) == list:
             for entry in shortcuts['shortcuts']:
-                entry.setdefault('AppName', '')
-                entry.setdefault('Exe', '')
-                if entry['AppName'] == new_entry['AppName'] and entry['Exe'] == new_entry['Exe']:
+                entry.setdefault('appname', '')
+                entry.setdefault('exe', '')
+                if entry['appname'] == new_entry['appname'] and entry['exe'] == new_entry['exe']:
                     entry_exists = True
                     break
             if not entry_exists:
                 shortcuts['shortcuts'].append(new_entry)
         elif type(shortcuts['shortcuts']) == dict:
             for key in shortcuts['shortcuts'].keys():
-                shortcuts['shortcuts'][key].setdefault('AppName', '')
-                shortcuts['shortcuts'][key].setdefault('Exe', '')
-                if shortcuts['shortcuts'][key]['AppName'] == new_entry['AppName'] and shortcuts['shortcuts'][key]['Exe'] == new_entry['Exe']:
+                shortcuts['shortcuts'][key].setdefault('appname', '')
+                shortcuts['shortcuts'][key].setdefault('exe', '')
+                if shortcuts['shortcuts'][key]['appname'] == new_entry['appname'] and shortcuts['shortcuts'][key]['exe'] == new_entry['exe']:
                     entry_exists = True
                     break
             if not entry_exists:
@@ -2523,8 +2523,8 @@ if originshortcutdirectory != '':
         # Create a new entry for the Steam shortcut
         new_entry = {
             'appid': f'{str(originappid)}',
-            'AppName': 'Origin',
-            'Exe': '$originshortcutdirectory',
+            'appname': 'Origin',
+            'exe': '$originshortcutdirectory',
             'StartDir': '$originshortcutdirectory',
             'icon': '',
             'ShortcutPath': '',
@@ -2545,18 +2545,18 @@ if originshortcutdirectory != '':
         entry_exists = False
         if type(shortcuts['shortcuts']) == list:
             for entry in shortcuts['shortcuts']:
-                entry.setdefault('AppName', '')
-                entry.setdefault('Exe', '')
-                if entry['AppName'] == new_entry['AppName'] and entry['Exe'] == new_entry['Exe']:
+                entry.setdefault('appname', '')
+                entry.setdefault('exe', '')
+                if entry['appname'] == new_entry['appname'] and entry['exe'] == new_entry['exe']:
                     entry_exists = True
                     break
             if not entry_exists:
                 shortcuts['shortcuts'].append(new_entry)
         elif type(shortcuts['shortcuts']) == dict:
             for key in shortcuts['shortcuts'].keys():
-                shortcuts['shortcuts'][key].setdefault('AppName', '')
-                shortcuts['shortcuts'][key].setdefault('Exe', '')
-                if shortcuts['shortcuts'][key]['AppName'] == new_entry['AppName'] and shortcuts['shortcuts'][key]['Exe'] == new_entry['Exe']:
+                shortcuts['shortcuts'][key].setdefault('appname', '')
+                shortcuts['shortcuts'][key].setdefault('exe', '')
+                if shortcuts['shortcuts'][key]['appname'] == new_entry['appname'] and shortcuts['shortcuts'][key]['exe'] == new_entry['exe']:
                     entry_exists = True
                     break
             if not entry_exists:
@@ -2580,8 +2580,8 @@ if battlenetshortcutdirectory != '':
         # Create a new entry for the Steam shortcut
         new_entry = {
             'appid': f'{str(battlenetappid)}',
-            'AppName': 'Battle.net',
-            'Exe': '$battlenetshortcutdirectory',
+            'appname': 'Battle.net',
+            'exe': '$battlenetshortcutdirectory',
             'StartDir': '$battlenetshortcutdirectory',
             'icon': '',
             'ShortcutPath': '',
@@ -2602,18 +2602,18 @@ if battlenetshortcutdirectory != '':
         entry_exists = False
         if type(shortcuts['shortcuts']) == list:
             for entry in shortcuts['shortcuts']:
-                entry.setdefault('AppName', '')
-                entry.setdefault('Exe', '')
-                if entry['AppName'] == new_entry['AppName'] and entry['Exe'] == new_entry['Exe']:
+                entry.setdefault('appname', '')
+                entry.setdefault('exe', '')
+                if entry['appname'] == new_entry['appname'] and entry['exe'] == new_entry['exe']:
                     entry_exists = True
                     break
             if not entry_exists:
                 shortcuts['shortcuts'].append(new_entry)
         elif type(shortcuts['shortcuts']) == dict:
             for key in shortcuts['shortcuts'].keys():
-                shortcuts['shortcuts'][key].setdefault('AppName', '')
-                shortcuts['shortcuts'][key].setdefault('Exe', '')
-                if shortcuts['shortcuts'][key]['AppName'] == new_entry['AppName'] and shortcuts['shortcuts'][key]['Exe'] == new_entry['Exe']:
+                shortcuts['shortcuts'][key].setdefault('appname', '')
+                shortcuts['shortcuts'][key].setdefault('exe', '')
+                if shortcuts['shortcuts'][key]['appname'] == new_entry['appname'] and shortcuts['shortcuts'][key]['exe'] == new_entry['exe']:
                     entry_exists = True
                     break
             if not entry_exists:
@@ -2638,8 +2638,8 @@ if eaappshortcutdirectory != '':
         # Create a new entry for the Steam shortcut
         new_entry = {
             'appid': f'{str(eaappid)}',
-            'AppName': 'EA App',
-            'Exe': '$eaappshortcutdirectory',
+            'appname': 'EA App',
+            'exe': '$eaappshortcutdirectory',
             'StartDir': '$eaappshortcutdirectory',
             'icon': '',
             'ShortcutPath': '',
@@ -2660,18 +2660,18 @@ if eaappshortcutdirectory != '':
         entry_exists = False
         if type(shortcuts['shortcuts']) == list:
             for entry in shortcuts['shortcuts']:
-                entry.setdefault('AppName', '')
-                entry.setdefault('Exe', '')
-                if entry['AppName'] == new_entry['AppName'] and entry['Exe'] == new_entry['Exe']:
+                entry.setdefault('appname', '')
+                entry.setdefault('exe', '')
+                if entry['appname'] == new_entry['appname'] and entry['exe'] == new_entry['exe']:
                     entry_exists = True
                     break
             if not entry_exists:
                 shortcuts['shortcuts'].append(new_entry)
         elif type(shortcuts['shortcuts']) == dict:
             for key in shortcuts['shortcuts'].keys():
-                shortcuts['shortcuts'][key].setdefault('AppName', '')
-                shortcuts['shortcuts'][key].setdefault('Exe', '')
-                if shortcuts['shortcuts'][key]['AppName'] == new_entry['AppName'] and shortcuts['shortcuts'][key]['Exe'] == new_entry['Exe']:
+                shortcuts['shortcuts'][key].setdefault('appname', '')
+                shortcuts['shortcuts'][key].setdefault('exe', '')
+                if shortcuts['shortcuts'][key]['appname'] == new_entry['appname'] and shortcuts['shortcuts'][key]['exe'] == new_entry['exe']:
                     entry_exists = True
                     break
             if not entry_exists:
@@ -2695,8 +2695,8 @@ if amazonshortcutdirectory != '':
         # Create a new entry for the Steam shortcut
         new_entry = {
             'appid': f'{str(amazonappid)}',
-            'AppName': 'Amazon Games',
-            'Exe': '$amazonshortcutdirectory',
+            'appname': 'Amazon Games',
+            'exe': '$amazonshortcutdirectory',
             'StartDir': '$amazonshortcutdirectory',
             'icon': '',
             'ShortcutPath': '',
@@ -2717,18 +2717,18 @@ if amazonshortcutdirectory != '':
         entry_exists = False
         if type(shortcuts['shortcuts']) == list:
             for entry in shortcuts['shortcuts']:
-                entry.setdefault('AppName', '')
-                entry.setdefault('Exe', '')
-                if entry['AppName'] == new_entry['AppName'] and entry['Exe'] == new_entry['Exe']:
+                entry.setdefault('appname', '')
+                entry.setdefault('exe', '')
+                if entry['appname'] == new_entry['appname'] and entry['exe'] == new_entry['exe']:
                     entry_exists = True
                     break
             if not entry_exists:
                 shortcuts['shortcuts'].append(new_entry)
         elif type(shortcuts['shortcuts']) == dict:
             for key in shortcuts['shortcuts'].keys():
-                shortcuts['shortcuts'][key].setdefault('AppName', '')
-                shortcuts['shortcuts'][key].setdefault('Exe', '')
-                if shortcuts['shortcuts'][key]['AppName'] == new_entry['AppName'] and shortcuts['shortcuts'][key]['Exe'] == new_entry['Exe']:
+                shortcuts['shortcuts'][key].setdefault('appname', '')
+                shortcuts['shortcuts'][key].setdefault('exe', '')
+                if shortcuts['shortcuts'][key]['appname'] == new_entry['appname'] and shortcuts['shortcuts'][key]['exe'] == new_entry['exe']:
                     entry_exists = True
                     break
             if not entry_exists:
@@ -2751,8 +2751,8 @@ if itchioshortcutdirectory != '':
         # Create a new entry for the Steam shortcut
         new_entry = {
             'appid': f'{str(itchioappid)}',
-            'AppName': 'itch.io',
-            'Exe': '$itchioshortcutdirectory',
+            'appname': 'itch.io',
+            'exe': '$itchioshortcutdirectory',
             'StartDir': '$itchioshortcutdirectory',
             'icon': '',
             'ShortcutPath': '',
@@ -2773,18 +2773,18 @@ if itchioshortcutdirectory != '':
         entry_exists = False
         if type(shortcuts['shortcuts']) == list:
             for entry in shortcuts['shortcuts']:
-                entry.setdefault('AppName', '')
-                entry.setdefault('Exe', '')
-                if entry['AppName'] == new_entry['AppName'] and entry['Exe'] == new_entry['Exe']:
+                entry.setdefault('appname', '')
+                entry.setdefault('exe', '')
+                if entry['appname'] == new_entry['appname'] and entry['exe'] == new_entry['exe']:
                     entry_exists = True
                     break
             if not entry_exists:
                 shortcuts['shortcuts'].append(new_entry)
         elif type(shortcuts['shortcuts']) == dict:
             for key in shortcuts['shortcuts'].keys():
-                shortcuts['shortcuts'][key].setdefault('AppName', '')
-                shortcuts['shortcuts'][key].setdefault('Exe', '')
-                if shortcuts['shortcuts'][key]['AppName'] == new_entry['AppName'] and shortcuts['shortcuts'][key]['Exe'] == new_entry['Exe']:
+                shortcuts['shortcuts'][key].setdefault('appname', '')
+                shortcuts['shortcuts'][key].setdefault('exe', '')
+                if shortcuts['shortcuts'][key]['appname'] == new_entry['appname'] and shortcuts['shortcuts'][key]['exe'] == new_entry['exe']:
                     entry_exists = True
                     break
             if not entry_exists:
@@ -2808,8 +2808,8 @@ if legacyshortcutdirectory != '':
         # Create a new entry for the Steam shortcut
         new_entry = {
             'appid': f'{str(legacyappid)}',
-            'AppName': 'Legacy Games',
-            'Exe': '$legacyshortcutdirectory',
+            'appname': 'Legacy Games',
+            'exe': '$legacyshortcutdirectory',
             'StartDir': '$legacyshortcutdirectory',
             'icon': '',
             'ShortcutPath': '',
@@ -2830,18 +2830,18 @@ if legacyshortcutdirectory != '':
         entry_exists = False
         if type(shortcuts['shortcuts']) == list:
             for entry in shortcuts['shortcuts']:
-                entry.setdefault('AppName', '')
-                entry.setdefault('Exe', '')
-                if entry['AppName'] == new_entry['AppName'] and entry['Exe'] == new_entry['Exe']:
+                entry.setdefault('appname', '')
+                entry.setdefault('exe', '')
+                if entry['appname'] == new_entry['appname'] and entry['exe'] == new_entry['exe']:
                     entry_exists = True
                     break
             if not entry_exists:
                 shortcuts['shortcuts'].append(new_entry)
         elif type(shortcuts['shortcuts']) == dict:
             for key in shortcuts['shortcuts'].keys():
-                shortcuts['shortcuts'][key].setdefault('AppName', '')
-                shortcuts['shortcuts'][key].setdefault('Exe', '')
-                if shortcuts['shortcuts'][key]['AppName'] == new_entry['AppName'] and shortcuts['shortcuts'][key]['Exe'] == new_entry['Exe']:
+                shortcuts['shortcuts'][key].setdefault('appname', '')
+                shortcuts['shortcuts'][key].setdefault('exe', '')
+                if shortcuts['shortcuts'][key]['appname'] == new_entry['appname'] and shortcuts['shortcuts'][key]['exe'] == new_entry['exe']:
                     entry_exists = True
                     break
             if not entry_exists:
@@ -2865,8 +2865,8 @@ if humbleshortcutdirectory != '':
         # Create a new entry for the Steam shortcut
         new_entry = {
             'appid': f'{str(humbleappid)}',
-            'AppName': 'Humble Games Collection',
-            'Exe': '$humbleshortcutdirectory',
+            'appname': 'Humble Games Collection',
+            'exe': '$humbleshortcutdirectory',
             'StartDir': '$humbleshortcutdirectory',
             'icon': '',
             'ShortcutPath': '',
@@ -2887,18 +2887,18 @@ if humbleshortcutdirectory != '':
         entry_exists = False
         if type(shortcuts['shortcuts']) == list:
             for entry in shortcuts['shortcuts']:
-                entry.setdefault('AppName', '')
-                entry.setdefault('Exe', '')
-                if entry['AppName'] == new_entry['AppName'] and entry['Exe'] == new_entry['Exe']:
+                entry.setdefault('appname', '')
+                entry.setdefault('exe', '')
+                if entry['appname'] == new_entry['appname'] and entry['exe'] == new_entry['exe']:
                     entry_exists = True
                     break
             if not entry_exists:
                 shortcuts['shortcuts'].append(new_entry)
         elif type(shortcuts['shortcuts']) == dict:
             for key in shortcuts['shortcuts'].keys():
-                shortcuts['shortcuts'][key].setdefault('AppName', '')
-                shortcuts['shortcuts'][key].setdefault('Exe', '')
-                if shortcuts['shortcuts'][key]['AppName'] == new_entry['AppName'] and shortcuts['shortcuts'][key]['Exe'] == new_entry['Exe']:
+                shortcuts['shortcuts'][key].setdefault('appname', '')
+                shortcuts['shortcuts'][key].setdefault('exe', '')
+                if shortcuts['shortcuts'][key]['appname'] == new_entry['appname'] and shortcuts['shortcuts'][key]['exe'] == new_entry['exe']:
                     entry_exists = True
                     break
             if not entry_exists:
@@ -2923,8 +2923,8 @@ if indieshortcutdirectory != '':
         # Create a new entry for the Steam shortcut
         new_entry = {
             'appid': f'{str(indieappid)}',
-            'AppName': 'IndieGala',
-            'Exe': '$indieshortcutdirectory',
+            'appname': 'IndieGala',
+            'exe': '$indieshortcutdirectory',
             'StartDir': '$indieshortcutdirectory',
             'icon': '',
             'ShortcutPath': '',
@@ -2945,18 +2945,18 @@ if indieshortcutdirectory != '':
         entry_exists = False
         if type(shortcuts['shortcuts']) == list:
             for entry in shortcuts['shortcuts']:
-                entry.setdefault('AppName', '')
-                entry.setdefault('Exe', '')
-                if entry['AppName'] == new_entry['AppName'] and entry['Exe'] == new_entry['Exe']:
+                entry.setdefault('appname', '')
+                entry.setdefault('exe', '')
+                if entry['appname'] == new_entry['appname'] and entry['exe'] == new_entry['exe']:
                     entry_exists = True
                     break
             if not entry_exists:
                 shortcuts['shortcuts'].append(new_entry)
         elif type(shortcuts['shortcuts']) == dict:
             for key in shortcuts['shortcuts'].keys():
-                shortcuts['shortcuts'][key].setdefault('AppName', '')
-                shortcuts['shortcuts'][key].setdefault('Exe', '')
-                if shortcuts['shortcuts'][key]['AppName'] == new_entry['AppName'] and shortcuts['shortcuts'][key]['Exe'] == new_entry['Exe']:
+                shortcuts['shortcuts'][key].setdefault('appname', '')
+                shortcuts['shortcuts'][key].setdefault('exe', '')
+                if shortcuts['shortcuts'][key]['appname'] == new_entry['appname'] and shortcuts['shortcuts'][key]['exe'] == new_entry['exe']:
                     entry_exists = True
                     break
             if not entry_exists:
@@ -2983,8 +2983,8 @@ if rockstarshortcutdirectory != '':
         # Create a new entry for the Steam shortcut
         new_entry = {
             'appid': f'{str(rockstarappid)}',
-            'AppName': 'Rockstar Games Launcher',
-            'Exe': '$rockstarshortcutdirectory',
+            'appname': 'Rockstar Games Launcher',
+            'exe': '$rockstarshortcutdirectory',
             'StartDir': '$rockstarshortcutdirectory',
             'icon': '',
             'ShortcutPath': '',
@@ -3005,18 +3005,18 @@ if rockstarshortcutdirectory != '':
         entry_exists = False
         if type(shortcuts['shortcuts']) == list:
             for entry in shortcuts['shortcuts']:
-                entry.setdefault('AppName', '')
-                entry.setdefault('Exe', '')
-                if entry['AppName'] == new_entry['AppName'] and entry['Exe'] == new_entry['Exe']:
+                entry.setdefault('appname', '')
+                entry.setdefault('exe', '')
+                if entry['appname'] == new_entry['appname'] and entry['exe'] == new_entry['exe']:
                     entry_exists = True
                     break
             if not entry_exists:
                 shortcuts['shortcuts'].append(new_entry)
         elif type(shortcuts['shortcuts']) == dict:
             for key in shortcuts['shortcuts'].keys():
-                shortcuts['shortcuts'][key].setdefault('AppName', '')
-                shortcuts['shortcuts'][key].setdefault('Exe', '')
-                if shortcuts['shortcuts'][key]['AppName'] == new_entry['AppName'] and shortcuts['shortcuts'][key]['Exe'] == new_entry['Exe']:
+                shortcuts['shortcuts'][key].setdefault('appname', '')
+                shortcuts['shortcuts'][key].setdefault('exe', '')
+                if shortcuts['shortcuts'][key]['appname'] == new_entry['appname'] and shortcuts['shortcuts'][key]['exe'] == new_entry['exe']:
                     entry_exists = True
                     break
             if not entry_exists:


### PR DESCRIPTION
Fixed an issue where Steam shortcuts would be recreated due to a property casing mismatch. Steam would change the casing of the properties used to check existing shortcuts after viewing or making a change to them.