### PR TITLE
changed NonSteamLaunchers.desktop exec (Again)

### DIFF
--- a/NonSteamLaunchers.desktop
+++ b/NonSteamLaunchers.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Comment[en_US]=
 Comment=
-Exec=sh -c 'curl -L https://raw.githubusercontent.com/moraroy/NonSteamLaunchers-On-Steam-Deck/main/NonSteamLaunchers.sh | /bin/bash'
+Exec=/bin/bash -c 'curl -Ls https://raw.githubusercontent.com/moraroy/NonSteamLaunchers-On-Steam-Deck/main/NonSteamLaunchers.sh | nohup /bin/bash'
 GenericName[en_US]=
 GenericName=
 Icon=uav


### PR DESCRIPTION
- Added /bin/bash for the first shell (to avoid using two different shells)
- Added -s Option for curl to hide statistics in Terminal Window
- Added nohup to second bash for detaching the Window (The Window does not disappear, but at least is closeable without any Problems)