### PR TITLE
Update handle-humble-scheme

### DIFF
--- a/humble-app/handle-humble-scheme
+++ b/humble-app/handle-humble-scheme
@@ -3,7 +3,7 @@
 set -e
 
 export STEAM_COMPAT_CLIENT_INSTALL_PATH=~/.local/share/Steam
-export STEAM_COMPAT_DATA_PATH=~/.steam/steam/Steam/steamapps/compatdata/APPID
+export STEAM_COMPAT_DATA_PATH=~/.steam/steam/steamapps/compatdata/APPID
 FIXED_SCHEME="$(echo "$1" | sed "s/?/\//")"
 
 echo $FIXED_SCHEME > /home/deck/.local/share/Steam/steamapps/compatdata/APPID/pfx/drive_c/.auth


### PR DESCRIPTION
Fixed line 6 - there is an extra "Steam" in the path.  It should read: 

export STEAM_COMPAT_DATA_PATH=~/.steam/steam/steamapps/compatdata/NonSteamLaunchers