### PR TITLE
Initial cleanup of core shell script

### DIFF
--- a/NonSteamLaunchers.sh
+++ b/NonSteamLaunchers.sh
@@ -1324,7 +1324,7 @@ if [[ $options == "Find Games" ]]; then
     # Add execute permissions to the linux_BoilR file
     chmod +x linux_BoilR
 
-    # TODO: brittle subshell proces; should create working directory variable and launch explicitly with `bash -c "linux_BoilR"`
+    # TODO: brittle subshell proces; should ~~create working directory variable~~ [edit: `download_dir`] and launch explicitly with `bash -c "linux_BoilR"`
     # Run BoilR from the current directory
     ./linux_BoilR
 

--- a/NonSteamLaunchers.sh
+++ b/NonSteamLaunchers.sh
@@ -2739,15 +2739,15 @@ while steam_pid > /dev/null; do sleep 5; done
 # Pre check for updating the config file
 
 # Set the default Steam directory
-steam_dir="${logged_in_home}/.steam/root"
+steam_dir_root="${logged_in_home}/.steam/root"
 
 # Set the path to the config.vdf file
-config_vdf_path="${steam_dir}/config/config.vdf"
+config_vdf_path="${steam_dir_root}/config/config.vdf"
 
 # Check if the config.vdf file exists
 if [ -f "$config_vdf_path" ]; then
     # Create a backup of the config.vdf file
-    backup_path="${steam_dir}/config/config.vdf.bak"
+    backup_path="${steam_dir_root}/config/config.vdf.bak"
     cp "$config_vdf_path" "$backup_path"
 
     # Set the name of the compatibility tool to use

--- a/NonSteamLaunchers.sh
+++ b/NonSteamLaunchers.sh
@@ -2,9 +2,6 @@
 
 # shellcheck disable=SC2155
 
-# Create a log file in the same directory as the desktop file/.sh file
-exec >> ${logged_in_home}/Downloads/NonSteamLaunchers-install.log 2>&1
-
 # TODO: this is silly -- if the script is being executed, doesn't need to mark itself as executable
 # * better to set permissions at a repo-level
 # * then an end user would have to explicitly call `chmod -x` to walk it back
@@ -14,8 +11,27 @@ set -x              # activate debugging (execution shown)
 set -o pipefail     # capture error from pipes
 # set -eu           # exit immediately, undefined vars are errors
 
+# ENVIRONMENT VARIABLES
+# $USER
+logged_in_user=$(logname)
+
+# $UID
+# logged_in_uid=$(id -u "${logged_in_user}")
+
+# $HOME
+logged_in_home=$(eval echo "~${logged_in_user}")
+
+# TODO: `/tmp` or `mktemp -d` might be a better option (see: EOF)
+# $PWD (working directory)
+download_dir="${logged_in_home}/Downloads/NonSteamLaunchersInstallation"
+
+# Create a log file in the same directory as the desktop file/.sh file
+exec >> ${logged_in_home}/Downloads/NonSteamLaunchers-install.log 2>&1
+
+# Version number (major.minor)
 version=v2.99
 
+# Check repo releases via GitHub API then display current stable version
 check_for_updates() {
     # Set the URL to the GitHub API for the repository
     local api_url="https://api.github.com/repos/moraroy/NonSteamLaunchers-On-Steam-Deck/releases/latest"
@@ -40,20 +56,6 @@ if [ ${#args[@]} -eq 0 ]; then
     # No command line arguments were provided, so check for updates and display the zenity window if necessary
     check_for_updates
 fi
-
-# ENVIRONMENT VARIABLES
-# $USER
-logged_in_user=$(logname)
-
-# $UID
-# logged_in_uid=$(id -u "${logged_in_user}")
-
-# $HOME
-logged_in_home=$(eval echo "~${logged_in_user}")
-
-# TODO: `/tmp` or `mktemp -d` might be a better option (see: EOF)
-# $PWD (working directory)
-download_dir="${logged_in_home}/Downloads/NonSteamLaunchersInstallation"
 
 # Check if the NonSteamLaunchersInstallation subfolder exists in the Downloads folder
 if [ -d "$download_dir" ]; then

--- a/NonSteamLaunchers.sh
+++ b/NonSteamLaunchers.sh
@@ -41,7 +41,7 @@ if [ ${#args[@]} -eq 0 ]; then
     check_for_updates
 fi
 
-# environment variables
+# ENVIRONMENT VARIABLES
 # $USER
 logged_in_user=$(logname)
 
@@ -51,10 +51,14 @@ logged_in_user=$(logname)
 # $HOME
 logged_in_home=$(eval echo "~${logged_in_user}")
 
+# TODO: `/tmp` or `mktemp -d` might be a better option (see: EOF)
+# $PWD (working directory)
+install_dir="${logged_in_home}/Downloads/NonSteamLaunchersInstallation"
+
 # Check if the NonSteamLaunchersInstallation subfolder exists in the Downloads folder
-if [ -d "${logged_in_home}/Downloads/NonSteamLaunchersInstallation" ]; then
+if [ -d "$install_dir" ]; then
     # Delete the NonSteamLaunchersInstallation subfolder
-    rm -rf "${logged_in_home}/Downloads/NonSteamLaunchersInstallation"
+    rm -rf "$install_dir"
     echo "Deleted NonSteamLaunchersInstallation subfolder"
 else
     echo "NonSteamLaunchersInstallation subfolder does not exist"
@@ -1305,14 +1309,14 @@ fi
 if [[ $options == "Find Games" ]]; then
     # The Find Games button was clicked
     # Check if the NonSteamLaunchersInstallation directory exists
-    if [[ ! -d "${logged_in_home}/Downloads/NonSteamLaunchersInstallation" ]]; then
+    if [[ ! -d "$install_dir" ]]; then
         # The directory does not exist, so create it
-        mkdir -p "${logged_in_home}/Downloads/NonSteamLaunchersInstallation"
+        mkdir -p "$install_dir"
     fi
 
     # Download the latest BoilR from GitHub (Linux version)
-    mkdir -p "${logged_in_home}/Downloads/NonSteamLaunchersInstallation"
-    cd "${logged_in_home}/Downloads/NonSteamLaunchersInstallation"
+    mkdir -p "$install_dir"
+    cd "$install_dir"
     wget https://github.com/PhilipK/BoilR/releases/download/v.1.9.1/linux_BoilR
 
     # Add execute permissions to the linux_BoilR file
@@ -2335,7 +2339,7 @@ fi
 wait
 
 # Delete NonSteamLaunchersInstallation subfolder in Downloads folder
-rm -rf "${logged_in_home}/Downloads/NonSteamLaunchersInstallation"
+rm -rf "$install_dir"
 
     echo "100"
     echo "# Installation Complete - Steam will now restart. Your launchers will be in your library!...Food for thought...do Jedis use Force Compatability?"
@@ -3140,4 +3144,4 @@ if os.path.exists(os.path.join(compatdata_dir, 'NonSteamLaunchers')):
 
 # TODO: might be better to relocate temp files to `/tmp` or even use `mktemp -d` since `rm -rf` is potentially dangerous without the `-i` flag
 # Delete NonSteamLaunchersInstallation subfolder in Downloads folder
-rm -rf "${logged_in_home}/Downloads/NonSteamLaunchersInstallation"
+rm -rf "$install_dir"

--- a/NonSteamLaunchers.sh
+++ b/NonSteamLaunchers.sh
@@ -2650,9 +2650,9 @@ export PYTHONPATH="${download_dir}/lib/python${python_version}/site-packages/:$P
 steam_dir="${logged_in_home}/.local/share/Steam"
 
 # Check if the config.vdf file exists
-if [[ -f "$steam_dir/config/config.vdf" ]]; then
+if [[ -f "${steam_dir}/config/config.vdf" ]]; then
     # Get the steamid of the currently logged in user
-    steamid=$(grep -oP 'SteamID"\s+"\K[0-9]+' "$steam_dir/config/config.vdf" | head -n 1)
+    steamid=$(grep -oP 'SteamID"\s+"\K[0-9]+' "${steam_dir}/config/config.vdf" | head -n 1)
 
     # Print out the value of steamid for debugging purposes
     echo "steamid: $steamid"
@@ -2742,12 +2742,12 @@ while steam_pid > /dev/null; do sleep 5; done
 steam_dir="${logged_in_home}/.steam/root"
 
 # Set the path to the config.vdf file
-config_vdf_path="$steam_dir/config/config.vdf"
+config_vdf_path="${steam_dir}/config/config.vdf"
 
 # Check if the config.vdf file exists
 if [ -f "$config_vdf_path" ]; then
     # Create a backup of the config.vdf file
-    backup_path="$steam_dir/config/config.vdf.bak"
+    backup_path="${steam_dir}/config/config.vdf.bak"
     cp "$config_vdf_path" "$backup_path"
 
     # Set the name of the compatibility tool to use

--- a/NonSteamLaunchers.sh
+++ b/NonSteamLaunchers.sh
@@ -415,7 +415,6 @@ function CheckInstallationDirectory {
         eaapplauncher_move_value="FALSE"
     fi
 
-
     # Check if AmazonGamesLauncher is installed
     if [[ -d "${logged_in_home}/.local/share/Steam/steamapps/compatdata/AmazonGamesLauncher" ]]; then
         # AmazonGamesLauncher is installed

--- a/NonSteamLaunchers.sh
+++ b/NonSteamLaunchers.sh
@@ -31,6 +31,7 @@ exec >> ${logged_in_home}/Downloads/NonSteamLaunchers-install.log 2>&1
 # Version number (major.minor)
 version=v2.99
 
+# TODO: tighten logic to check whether major/minor version is up-to-date via `-eq`, `-lt`, or `-gt` operators
 # Check repo releases via GitHub API then display current stable version
 check_for_updates() {
     # Set the URL to the GitHub API for the repository

--- a/NonSteamLaunchers.sh
+++ b/NonSteamLaunchers.sh
@@ -3138,5 +3138,6 @@ if os.path.exists(os.path.join(compatdata_dir, 'NonSteamLaunchers')):
     # Create a symbolic link to the renamed NonSteamLaunchers folder
     os.symlink(new_path, symlink_path)"
 
+# TODO: might be better to relocate temp files to `/tmp` or even use `mktemp -d` since `rm -rf` is potentially dangerous without the `-i` flag
 # Delete NonSteamLaunchersInstallation subfolder in Downloads folder
 rm -rf "${logged_in_home}/Downloads/NonSteamLaunchersInstallation"

--- a/NonSteamLaunchers.sh
+++ b/NonSteamLaunchers.sh
@@ -11,7 +11,8 @@ exec >> ${logged_in_home}/Downloads/NonSteamLaunchers-install.log 2>&1
 chmod +x "$0"
 
 set -x              # activate debugging (execution shown)
-set -euo pipefail   # exit immediately, undefined vars are errors, capture error from pipes
+set -o pipefail     # capture error from pipes
+# set -eu           # exit immediately, undefined vars are errors
 
 version=v2.99
 
@@ -545,6 +546,7 @@ else
         fi
     done
 
+    # TODO: error handling for unbound variable $selected_launchers_str on line 564
     # Convert the selected_launchers array to a string by joining its elements with a `|` delimiter.
     selected_launchers_str=$(IFS="|"; echo "${selected_launchers[*]}")
 
@@ -2723,14 +2725,13 @@ fi
 # Detach script from Steam process
 nohup sh -c 'sleep 10; /usr/bin/steam' &
 
-# TODO: should probably verify exact process name (see below)
 # Close all instances of Steam
-killall steam
+steam_pid() { pgrep -x steam ; }
+steam_running=$(steam_pid)
+[[ -n "$steam_running" ]] && killall steam
 
-# TODO: control for exact process names (currently catches all processes with steam in name)
-# * possibly `pgrep -x steam`
 # Wait for the steam process to exit
-while pgrep steam > /dev/null; do sleep 1; done
+while steam_pid > /dev/null; do sleep 5; done
 
 # Pre check for updating the config file
 
@@ -3138,4 +3139,4 @@ if os.path.exists(os.path.join(compatdata_dir, 'NonSteamLaunchers')):
     os.symlink(new_path, symlink_path)"
 
 # Delete NonSteamLaunchersInstallation subfolder in Downloads folder
-rm -rf ~/Downloads/NonSteamLaunchersInstallation
+rm -rf "${logged_in_home}/Downloads/NonSteamLaunchersInstallation"

--- a/NonSteamLaunchers.sh
+++ b/NonSteamLaunchers.sh
@@ -1,13 +1,19 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+# shellcheck disable=SC2155
 
 # Create a log file in the same directory as the desktop file/.sh file
 exec >> $HOME/Downloads/NonSteamLaunchers-install.log 2>&1
 
+# TODO: this is silly -- if the script is being executed, doesn't need to mark itself as executable
+# * better to set permissions at a repo-level
+# * then an end user would have to explicitly call `chmod -x` to walk it back
 chmod +x "$0"
 
-set -x
+set -x              # activate debugging (execution shown)
+set -euo pipefail   # exit immediately, undefined vars are errors, capture error from pipes
 
-version=v2.98
+version=v2.99
 
 check_for_updates() {
     # Set the URL to the GitHub API for the repository
@@ -34,12 +40,6 @@ if [ ${#args[@]} -eq 0 ]; then
     check_for_updates
 fi
 
-
-
-
-
-
-
 # Check if the NonSteamLaunchersInstallation subfolder exists in the Downloads folder
 if [ -d "$HOME/Downloads/NonSteamLaunchersInstallation" ]; then
     # Delete the NonSteamLaunchersInstallation subfolder
@@ -49,21 +49,9 @@ else
     echo "NonSteamLaunchersInstallation subfolder does not exist"
 fi
 
+# Game Launchers
 
-
-
-
-
-
-
-
-
-
-
-
-
-#Game Launchers
-
+# TODO: parameterize hard-coded client versions (cf. 'app-25.6.2')
 # Set the paths to the launcher executables
 epic_games_launcher_path1="$HOME/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/pfx/drive_c/Program Files (x86)/Epic Games/Launcher/Portal/Binaries/Win32/EpicGamesLauncher.exe"
 epic_games_launcher_path2="$HOME/.local/share/Steam/steamapps/compatdata/EpicGamesLauncher/pfx/drive_c/Program Files (x86)/Epic Games/Launcher/Portal/Binaries/Win32/EpicGamesLauncher.exe"
@@ -98,35 +86,13 @@ psplus_path2="$HOME/.local/share/Steam/steamapps/compatdata/PlaystationPlusLaunc
 dmm_path1="$HOME/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/pfx/drive_c/Program Files/DMMGamePlayer/DMMGamePlayer.exe"
 dmm_path2="$HOME/.local/share/Steam/steamapps/compatdata/DMMGameLauncher/pfx/drive_c/Program Files/DMMGamePlayer/DMMGamePlayer.exe"
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-#Chrome File Path
-#chrome_installpath="/app/bin/chrome"
+# Chrome File Path
+# chrome_installpath="/app/bin/chrome"
 chrome_path="/usr/bin/flatpak"
 chrome_startdir="\"/usr/bin\""
 
-
-
-
-
-
-
-function CheckInstallations {
 # Check if Epic Games Launcher is installed
+function CheckInstallations {
 if [[ -f "$epic_games_launcher_path1" ]]; then
     # Epic Games Launcher is installed in path 1
     epic_games_value="FALSE"
@@ -366,14 +332,7 @@ else
     dmm_text="DMM Games"
 fi }
 
-
-
-
-
-
-
-
-
+# Verify launchers are installed
 function CheckInstallationDirectory {
     # Check if NonSteamLaunchers is installed
     if [[ -d "$HOME/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers" ]]; then
@@ -492,7 +451,7 @@ function CheckInstallationDirectory {
         # rockstar games launcher is not installed
         rockstargameslauncher_move_value="FALSE"
     fi
-    
+
     # Check if Glyph is installed
     if [[ -d "$HOME/.local/share/Steam/steamapps/compatdata/GlyphLauncher" ]]; then
         # Glyph is installed
@@ -511,6 +470,7 @@ function CheckInstallationDirectory {
         minecraftlauncher_move_value="FALSE"
     fi
 
+    # TODO: `pspluslauncher_move_value` is unused (SC2034)
     # Check if PlaystationPlus is installed
     if [[ -d "$HOME/.local/share/Steam/steamapps/compatdata/PlaystationPlusLauncher" ]]; then
         # PlaystationPlus is installed
@@ -529,12 +489,9 @@ function CheckInstallationDirectory {
         dmmlauncher_move_value="FALSE"
     fi }
 
-
-
 # Check which app IDs are installed
 CheckInstallations
 CheckInstallationDirectory
-
 
 # Get the command line arguments
 args=("$@")
@@ -557,8 +514,6 @@ if [ ${#args[@]} -eq 0 ]; then
     else
         # The user did not click the 'Cancel' button or select one of the extra buttons, so prompt for custom websites
         custom_websites_str=$(zenity --entry --title="Shortcut Creator" --text="Enter custom websites that you want shortcuts for, separated by commas. Leave blank and press ok if you dont want any. E.g. myspace.com, limewire.com, my.screenname.aol.com")
-
-
 
         # Split the custom_websites_str variable into an array using ',' as the delimiter
         IFS=',' read -ra custom_websites <<< "$custom_websites_str"
@@ -591,14 +546,12 @@ else
     fi
 fi
 
-
+# TODO: SC2145
 # Print the selected launchers and custom websites
 echo "Selected launchers: $selected_launchers"
 echo "Selected launchers: $selected_launchers_str"
 echo "Custom websites: ${custom_websites[@]}"
 echo "Separate App IDs: $separate_app_ids"
-
-
 
 # Set the value of the options variable
 if [ ${#args[@]} -eq 0 ]; then
@@ -608,10 +561,6 @@ else
     # Command line arguments were provided, so set the value of the options variable using the selected_launchers_str variable
     options="$selected_launchers_str"
 fi
-
-
-
-
 
 # Check if the cancel button was clicked
 if [ $? -eq 1 ] && [[ $options != "Start Fresh" ]] && [[ $options != "Move to SD Card" ]] && [[ $options != "Uninstall" ]] && [[ $options != "Find Games" ]]; then
@@ -627,10 +576,6 @@ if [ -z "$options" ] && [ -z "$custom_websites" ]; then
     exit 1
 fi
 
-
-
-
-
 # Check if the user selected to use separate app IDs
 if [[ $options == *"SEPARATE APP IDS - CHECK THIS TO SEPARATE YOUR PREFIX'S"* ]]; then
     # User selected to use separate app IDs
@@ -640,21 +585,12 @@ else
     use_separate_appids=false
 fi
 
-
-
-
-
-
-
 # Check if the user selected both Origin and EA App
 if [[ $options == *"Origin"* ]] && [[ $options == *"EA App"* ]] && [ "$use_separate_appids" = false ]; then
     # User selected both Origin and EA App without selecting separate app IDs
     zenity --error --text="You cannot select both Origin and EA App at the same time unless you select separate app IDs." --width=200 --height=150
     exit 1
 fi
-
-
-
 
 # Check if Origin is already installed
 if [[ -f "$origin_path1" ]] || [[ -f "$origin_path2" ]]; then
@@ -666,9 +602,6 @@ if [[ -f "$origin_path1" ]] || [[ -f "$origin_path2" ]]; then
     fi
 fi
 
-
-
-
 # Check if EA App is already installed
 if [[ -f "$eaapp_path1" ]] || [[ -f "$eaapp_path2" ]]; then
     # EA App is installed
@@ -678,15 +611,6 @@ if [[ -f "$eaapp_path1" ]] || [[ -f "$eaapp_path2" ]]; then
         exit 1
     fi
 fi
-
-
-
-
-
-
-
-
-
 
 # Define the StartFreshFunction
 function StartFreshFunction {
@@ -699,20 +623,21 @@ function StartFreshFunction {
     # Iterate over each folder name in the folder_names array
     for folder in "${folder_names[@]}"; do
         # Check if the folder exists
-        if [ -e "$compatdata_dir/$folder" ]; then
+        if [ -e "${compatdata_dir}/${folder}" ]; then
             # Check if the folder is a symbolic link
-            if [ -L "$compatdata_dir/$folder" ]; then
+            if [ -L "${compatdata_dir}/${folder}" ]; then
                 # Get the path of the target of the symbolic link
-                target_path=$(readlink -f "$compatdata_dir/$folder")
+                target_path=$(readlink -f "${compatdata_dir}/${folder}")
 
                 # Delete the target of the symbolic link
                 rm -rf "$target_path"
 
                 # Delete the symbolic link
-                unlink "$compatdata_dir/$folder"
+                unlink "${compatdata_dir}/${folder}"
             else
                 # Delete the folder
-                rm -rf "$compatdata_dir/$folder"
+                # shellcheck disable=SC2115
+                rm -rf "${compatdata_dir}/${folder}"
             fi
         fi
     done
@@ -748,6 +673,7 @@ function StartFreshFunction {
         fi
     done
 
+    # TODO: declare array and use find/for loop to avoid duplicate `rm` processes
     rm -rf "/run/media/mmcblk0p1/NonSteamLaunchers/"
     rm -rf "/run/media/mmcblk0p1/EpicGamesLauncher/"
     rm -rf "/run/media/mmcblk0p1/GogGalaxyLauncher/"
@@ -789,7 +715,6 @@ if [[ $options == "Start Fresh" ]] || [[ $selected_launchers == "Start Fresh" ]]
     fi
 fi
 
-
 if [[ $options == "Uninstall" ]]; then
 # Check if the cancel button was clicked
     # The OK button was not clicked
@@ -815,7 +740,6 @@ if [[ $options == "Uninstall" ]]; then
         FALSE "Minecraft"\
         FALSE "Playstation Plus"\
         FALSE "DMM Games")
-
 
     if [[ $options != "" ]]; then
         # The Uninstall button was clicked
@@ -1051,26 +975,12 @@ if [[ $options == "Uninstall" ]]; then
   exit
 fi
 
-
-
-
-
-
-
-
-
-
-
-
-
-
 if [[ $options == "Move to SD Card" ]]; then
     # The Move to SD Card button was clicked
     # Check which app IDs are installed
 
     # Add similar checks for other app IDs here
     CheckInstallationDirectory
-
 
     move_options=$(zenity --list --text="Which app IDs do you want to move to the SD card?" --checklist --column="Select" --column="App ID" $nonsteamlauncher_move_value "NonSteamLaunchers" $epicgameslauncher_move_value "EpicGamesLauncher" $goggalaxylauncher_move_value "GogGalaxyLauncher" $originlauncher_move_value "OriginLauncher" $uplaylauncher_move_value "UplayLauncher" $battlenetlauncher_move_value "Battle.netLauncher" $eaapplauncher_move_value "TheEAappLauncher" $amazongameslauncher_move_value "AmazonGamesLauncher" $itchiolauncher_move_value "itchioLauncher" $legacygameslauncher_move_value "LegacyGamesLauncher" $humblegameslauncher_move_value "HumbleGamesLauncher" $indiegalalauncher_move_value "IndieGalaLauncher" $rockstargameslauncher_move_value "RockstarGamesLauncher" $glyphlauncher_move_value "GlyphLauncher" $minecraftlauncher_move_value "MinecraftLauncher" $dmmlauncher_move_value "DMMGameLauncher" --width=335 --height=524)
 
@@ -1084,95 +994,94 @@ if [[ $options == "Move to SD Card" ]]; then
     # Set the path to the new directory on the SD card
     new_dir="/run/media/mmcblk0p1"
 
-
     # Check if NonSteamLaunchers is installed
     if [[ -d "$HOME/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers" ]]; then
-    # NonSteamLaunchers is installed
-    original_dir="$HOME/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers"
+        # NonSteamLaunchers is installed
+        original_dir="$HOME/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers"
     else
-    # NonSteamLaunchers is not installed
-    original_dir=""
+        # NonSteamLaunchers is not installed
+        original_dir=""
     fi
 
     # Check if the user selected to move NonSteamLaunchers
     if [[ $move_options == *"NonSteamLaunchers"* ]] && [[ -n $original_dir ]]; then
-    # Move the NonSteamLaunchers directory to the SD card
-    mv "$original_dir" "$new_dir/NonSteamLaunchers"
+        # Move the NonSteamLaunchers directory to the SD card
+        mv "$original_dir" "$new_dir/NonSteamLaunchers"
 
-    # Create a symbolic link to the new directory
-    ln -s "$new_dir/NonSteamLaunchers" "$original_dir"
+        # Create a symbolic link to the new directory
+        ln -s "$new_dir/NonSteamLaunchers" "$original_dir"
     fi
 
     # Check if EpicGamesLauncher is installed
     if [[ -d "$HOME/.local/share/Steam/steamapps/compatdata/EpicGamesLauncher" ]]; then
-    # EpicGamesLauncher is installed
-    original_dir="$HOME/.local/share/Steam/steamapps/compatdata/EpicGamesLauncher"
+        # EpicGamesLauncher is installed
+        original_dir="$HOME/.local/share/Steam/steamapps/compatdata/EpicGamesLauncher"
     else
-    # EpicGamesLauncher is not installed
-    original_dir=""
+        # EpicGamesLauncher is not installed
+        original_dir=""
     fi
 
     # Check if the user selected to move EpicGamesLauncher
     if [[ $move_options == *"EpicGamesLauncher"* ]] && [[ -n $original_dir ]]; then
-    # Move the EpicGamesLauncher directory to the SD card
-    mv "$original_dir" "$new_dir/EpicGamesLauncher"
+        # Move the EpicGamesLauncher directory to the SD card
+        mv "$original_dir" "$new_dir/EpicGamesLauncher"
 
-    # Create a symbolic link to the new directory
-    ln -s "$new_dir/EpicGamesLauncher" "$original_dir"
+        # Create a symbolic link to the new directory
+        ln -s "$new_dir/EpicGamesLauncher" "$original_dir"
     fi
 
     # Check if GogGalaxyLauncher is installed
     if [[ -d "$HOME/.local/share/Steam/steamapps/compatdata/GogGalaxyLauncher" ]]; then
-    # GogGalaxyLauncher is installed
-    original_dir="$HOME/.local/share/Steam/steamapps/compatdata/GogGalaxyLauncher"
+        # GogGalaxyLauncher is installed
+        original_dir="$HOME/.local/share/Steam/steamapps/compatdata/GogGalaxyLauncher"
     else
-    # GogGalaxyLauncher is not installed
-    original_dir=""
+        # GogGalaxyLauncher is not installed
+        original_dir=""
     fi
 
     # Check if the user selected to move GogGalaxyLauncher
     if [[ $move_options == *"GogGalaxyLauncher"* ]] && [[ -n $original_dir ]]; then
-    # Move the GogGalaxyLauncher directory to the SD card
-    mv "$original_dir" "$new_dir/GogGalaxyLauncher"
+        # Move the GogGalaxyLauncher directory to the SD card
+        mv "$original_dir" "$new_dir/GogGalaxyLauncher"
 
-    # Create a symbolic link to the new directory
-    ln -s "$new_dir/GogGalaxyLauncher" "$original_dir"
+        # Create a symbolic link to the new directory
+        ln -s "$new_dir/GogGalaxyLauncher" "$original_dir"
     fi
 
     # Check if OriginLauncher is installed
     if [[ -d "$HOME/.local/share/Steam/steamapps/compatdata/OriginLauncher" ]]; then
-    # OriginLauncher is installed
-    original_dir="$HOME/.local/share/Steam/steamapps/compatdata/OriginLauncher"
+        # OriginLauncher is installed
+        original_dir="$HOME/.local/share/Steam/steamapps/compatdata/OriginLauncher"
     else
-    # OriginLauncher is not installed
-    original_dir=""
+        # OriginLauncher is not installed
+        original_dir=""
     fi
 
     # Check if the user selected to move OriginLauncher
     if [[ $move_options == *"OriginLauncher"* ]] && [[ -n $original_dir ]]; then
-    # Move the OriginLauncher directory to the SD card
-    mv "$original_dir" "$new_dir/OriginLauncher"
+        # Move the OriginLauncher directory to the SD card
+        mv "$original_dir" "$new_dir/OriginLauncher"
 
-    # Create a symbolic link to the new directory
-    ln -s "$new_dir/OriginLauncher" "$original_dir"
+        # Create a symbolic link to the new directory
+        ln -s "$new_dir/OriginLauncher" "$original_dir"
     fi
 
     # Check if UplayLauncher is installed
     if [[ -d "$HOME/.local/share/Steam/steamapps/compatdata/UplayLauncher" ]]; then
-    # UplayLauncher is installed
-    original_dir="$HOME/.local/share/Steam/steamapps/compatdata/UplayLauncher"
+        # UplayLauncher is installed
+        original_dir="$HOME/.local/share/Steam/steamapps/compatdata/UplayLauncher"
     else
-    # UplayLauncher is not installed
-    original_dir=""
+        # UplayLauncher is not installed
+        original_dir=""
     fi
 
     # Check if the user selected to move UplayLauncher
     if [[ $move_options == *"UplayLauncher"* ]] && [[ -n $original_dir ]]; then
-    # Move the UplayLauncher directory to the SD card
-    mv "$original_dir" "$new_dir/UplayLauncher"
+        # Move the UplayLauncher directory to the SD card
+        mv "$original_dir" "$new_dir/UplayLauncher"
 
-    # Create a symbolic link to the new directory
-    ln -s "$new_dir/UplayLauncher" "$original_dir"
+        # Create a symbolic link to the new directory
+        ln -s "$new_dir/UplayLauncher" "$original_dir"
     fi
 
     # Check if Battle.netLauncher is installed
@@ -1258,11 +1167,11 @@ if [[ $options == "Move to SD Card" ]]; then
 
     # Check if the user selected to move LegacyGamesLauncher
     if [[ $move_options == *"LegacyGamesLauncher"* ]] && [[ -n $original_dir ]]; then
-    # Move the LegacyGamesLauncher directory to the SD card
-    mv "$original_dir" "$new_dir/LegacyGamesLauncher"
+        # Move the LegacyGamesLauncher directory to the SD card
+        mv "$original_dir" "$new_dir/LegacyGamesLauncher"
 
-    # Create a symbolic link to the new directory
-    ln -s "$new_dir/LegacyGamesLauncher" "$original_dir"
+        # Create a symbolic link to the new directory
+        ln -s "$new_dir/LegacyGamesLauncher" "$original_dir"
     fi
 
     # Check if HumbleGamesLauncher is installed
@@ -1373,18 +1282,11 @@ if [[ $options == "Move to SD Card" ]]; then
         ln -s "$new_dir/DMMGameLauncher" "$original_dir"
     fi
 
-
-
-
+    # TODO: verfiy non-zero exit is necessary
+    # ! Why the non-zero return?
     # Exit the script
     exit 1
-
 fi
-
-
-
-
-
 
 # Check if the user clicked the "Find Games" button
 if [[ $options == "Find Games" ]]; then
@@ -1396,12 +1298,14 @@ if [[ $options == "Find Games" ]]; then
     fi
 
     # Download the latest BoilR from GitHub (Linux version)
+    mkdir -p "$HOME/Downloads/NonSteamLaunchersInstallation"
     cd "$HOME/Downloads/NonSteamLaunchersInstallation"
     wget https://github.com/PhilipK/BoilR/releases/download/v.1.9.1/linux_BoilR
 
     # Add execute permissions to the linux_BoilR file
     chmod +x linux_BoilR
 
+    # TODO: brittle subshell proces; should create working directory variable and launch explicitly with `bash -c "linux_BoilR"`
     # Run BoilR from the current directory
     ./linux_BoilR
 
@@ -1409,19 +1313,9 @@ if [[ $options == "Find Games" ]]; then
     exit
 fi
 
-
-
-
-
-
-
-
-
-
-
+# TODO: probably better to break this subshell into a function that can then be redirected to zenity
+# Massive subshell pipes into `zenity --progress` around L2320 for GUI rendering
 (
-
-
 
 echo "0"
 echo "# Detecting, Updating and Installing GE-Proton"
@@ -1430,11 +1324,6 @@ echo "# Detecting, Updating and Installing GE-Proton"
     if [ ! -d "$HOME/.steam/root/compatibilitytools.d" ]; then
     mkdir -p "$HOME/.steam/root/compatibilitytools.d"
 fi
-
-
-
-
-
 
 # Create NonSteamLaunchersInstallation subfolder in Downloads folder
 mkdir -p ~/Downloads/NonSteamLaunchersInstallation
@@ -1445,10 +1334,6 @@ proton_dir=$(find ~/.steam/root/compatibilitytools.d -maxdepth 1 -type d -name "
 # Set the URLs to download GE-Proton from
 ge_proton_url1=https://github.com/GloriousEggroll/proton-ge-custom/releases/latest/download/GE-Proton.tar.gz
 ge_proton_url2=https://github.com/GloriousEggroll/proton-ge-custom/releases/download/GE-Proton8-11/GE-Proton8-11.tar.gz
-
-
-
-
 
 # Check if GE-Proton is installed
 if [ -z "$proton_dir" ]; then
@@ -1503,13 +1388,8 @@ installed_version=$(basename $proton_dir | sed 's/GE-Proton-//')
     fi
 fi
 
-
-
-
 echo "10"
 echo "# Setting files in their place"
-
-
 
 # Set the appid for the non-Steam game
 appid=NonSteamLaunchers
@@ -1610,11 +1490,8 @@ dmm_url=https://apidgp-gameplayer.games.dmm.com/archive/latest?app=dgp5win
 # Set the path to save the Playstation Launcher to
 dmm_file=~/Downloads/NonSteamLaunchersInstallation/DMMGamePlayer-Setup-5.2.16.exe
 
-
-
 echo "20"
 echo "# Creating files & folders"
-
 
 # Check if the user selected any launchers
 if [ -n "$options" ]; then
@@ -1626,26 +1503,17 @@ if [ -n "$options" ]; then
     fi
 fi
 
-
-
 # Change working directory to Proton's
 cd $proton_dir
 
 # Set the STEAM_RUNTIME environment variable
 export STEAM_RUNTIME="$HOME/.steam/root/ubuntu12_32/steam-runtime/run.sh"
 
-
 # Set the STEAM_COMPAT_CLIENT_INSTALL_PATH environment variable
-export STEAM_COMPAT_CLIENT_INSTALL_PATH="~/.local/share/Steam"
+export STEAM_COMPAT_CLIENT_INSTALL_PATH="$HOME/.local/share/Steam"
 
 # Set the STEAM_COMPAT_DATA_PATH environment variable for the first file
-export STEAM_COMPAT_DATA_PATH=~/.local/share/Steam/steamapps/compatdata/$appid
-
-
-
-
-
-
+export STEAM_COMPAT_DATA_PATH="$HOME/.local/share/Steam/steamapps/compatdata/${appid}"
 
 wait
 echo "30"
@@ -1656,135 +1524,121 @@ if [[ $options == *"Epic Games"* ]]; then
     # User selected Epic Games Launcher
     echo "User selected Epic Games"
 
+    # Set the appid for the Epic Games Launcher
+    if [ "$use_separate_appids" = true ]; then
+    appid=EpicGamesLauncher
+    else
+    appid=NonSteamLaunchers
+    fi
 
-        # Set the appid for the Epic Games Launcher
-        if [ "$use_separate_appids" = true ]; then
-        appid=EpicGamesLauncher
-        else
-        appid=NonSteamLaunchers
-        fi
+    # Create app id folder in compatdata folder if it doesn't exist
+    if [ ! -d "$HOME/.local/share/Steam/steamapps/compatdata/$appid" ]; then
+        mkdir -p "$HOME/.local/share/Steam/steamapps/compatdata/$appid"
+    fi
 
+    # Change working directory to Proton's
+    cd $proton_dir
 
-        # Create app id folder in compatdata folder if it doesn't exist
-        if [ ! -d "$HOME/.local/share/Steam/steamapps/compatdata/$appid" ]; then
-            mkdir -p "$HOME/.local/share/Steam/steamapps/compatdata/$appid"
-        fi
+    # Set the STEAM_COMPAT_CLIENT_INSTALL_PATH environment variable
+    export STEAM_COMPAT_CLIENT_INSTALL_PATH="$HOME/.local/share/Steam"
 
-        # Change working directory to Proton's
-        cd $proton_dir
+    # Set the STEAM_COMPAT_DATA_PATH environment variable for Epic Games Launcher
+    export STEAM_COMPAT_DATA_PATH="$HOME/.local/share/Steam/steamapps/compatdata/${appid}"
 
-        # Set the STEAM_COMPAT_CLIENT_INSTALL_PATH environment variable
-        export STEAM_COMPAT_CLIENT_INSTALL_PATH="~/.local/share/Steam"
+    # Download MSI file
+    if [ ! -f "$msi_file" ]; then
+        echo "Downloading MSI file"
+        wget $msi_url -O $msi_file
+    fi
 
-        # Set the STEAM_COMPAT_DATA_PATH environment variable for Epic Games Launcher
-        export STEAM_COMPAT_DATA_PATH=~/.local/share/Steam/steamapps/compatdata/$appid
-
-
-        # Download MSI file
-        if [ ! -f "$msi_file" ]; then
-            echo "Downloading MSI file"
-            wget $msi_url -O $msi_file
-        fi
-
-        # Run the MSI file using Proton with the /passive option
-        echo "Running MSI file using Proton with the /passive option"
-        "$STEAM_RUNTIME" "$proton_dir/proton" run MsiExec.exe /i "$msi_file" /qn
-
+    # Run the MSI file using Proton with the /passive option
+    echo "Running MSI file using Proton with the /passive option"
+    "$STEAM_RUNTIME" "$proton_dir/proton" run MsiExec.exe /i "$msi_file" /qn
 fi
 
-
+# TODO: capture PID of each `wait` process to make sure it's not an infinite loop
 # Wait for the MSI file to finish running
 wait
 echo "40"
 echo "# Downloading & Installing Gog Galaxy...please wait..."
-
 
 # Check if the user selected GOG Galaxy
 if [[ $options == *"GOG Galaxy"* ]]; then
     # User selected GOG Galaxy
     echo "User selected GOG Galaxy"
 
-
-        # Set the appid for the Gog Galaxy 2.0
-        if [ "$use_separate_appids" = true ]; then
-            appid=GogGalaxyLauncher
-        else
-            appid=NonSteamLaunchers
-        fi
-
-        # Create app id folder in compatdata folder if it doesn't exist
-        if [ ! -d "$HOME/.local/share/Steam/steamapps/compatdata/$appid" ]; then
-            mkdir -p "$HOME/.local/share/Steam/steamapps/compatdata/$appid"
-        fi
-
-        # Change working directory to Proton's
-        cd $proton_dir
-
-        # Set the STEAM_COMPAT_CLIENT_INSTALL_PATH environment variable
-        export STEAM_COMPAT_CLIENT_INSTALL_PATH="~/.local/share/Steam"
-
-        # Set the STEAM_COMPAT_DATA_PATH environment variable for Epic Games Launcher
-        export STEAM_COMPAT_DATA_PATH=~/.local/share/Steam/steamapps/compatdata/$appid
-
-        # Download EXE file
-        if [ ! -f "$exe_file" ]; then
-            echo "Downloading EXE file"
-            wget $exe_url -O $exe_file
-        fi
-
-        # Run the EXE file using Proton without the /passive option
-        echo "Running EXE file using Proton without the /passive option"
-        "$STEAM_RUNTIME" "$proton_dir/proton" run "$exe_file" &
-
-        echo "45"
-        echo "# Downloading & Installing Gog Galaxy...Please wait..."
-
-        # Cancel & Exit the GOG Galaxy Setup Wizard
-        while true; do
-            if pgrep -f "GalaxySetup.tmp" > /dev/null; then
-                pkill -f "GalaxySetup.tmp"
-                break
-            fi
-            sleep 1
-        done
-
-        # Navigate to %LocalAppData%\Temp
-        cd "$HOME/.local/share/Steam/steamapps/compatdata/$appid/pfx/drive_c/users/steamuser/Temp"
-
-        # Find the GalaxyInstaller_XXXXX folder and copy it to C:\Downloads
-        galaxy_installer_folder=$(find . -maxdepth 1 -type d -name "GalaxyInstaller_*" | head -n1)
-        cp -r "$galaxy_installer_folder" ~/Downloads/NonSteamLaunchersInstallation/
-
-        # Navigate to the C:\Downloads\GalaxyInstaller_XXXXX folder
-        cd ~/Downloads/NonSteamLaunchersInstallation/"$(basename $galaxy_installer_folder)"
-
-        # Run GalaxySetup.exe with the /VERYSILENT and /NORESTART options
-        echo "Running GalaxySetup.exe with the /VERYSILENT and /NORESTART options"
-        "$STEAM_RUNTIME" "$proton_dir/proton" run GalaxySetup.exe /VERYSILENT /NORESTART
-
-        # Wait for the EXE file to finish running
-        wait
-
+    # Set the appid for the Gog Galaxy 2.0
+    if [ "$use_separate_appids" = true ]; then
+        appid=GogGalaxyLauncher
     else
-        # Gog Galaxy Launcher is already installed
-        echo "Gog Galaxy Launcher is already installed"
+        appid=NonSteamLaunchers
+    fi
 
+    # Create app id folder in compatdata folder if it doesn't exist
+    if [ ! -d "$HOME/.local/share/Steam/steamapps/compatdata/$appid" ]; then
+        mkdir -p "$HOME/.local/share/Steam/steamapps/compatdata/$appid"
+    fi
+
+    # Change working directory to Proton's
+    cd "$proton_dir"
+
+    # Set the STEAM_COMPAT_CLIENT_INSTALL_PATH environment variable
+    export STEAM_COMPAT_CLIENT_INSTALL_PATH="$HOME/.local/share/Steam"
+
+    # Set the STEAM_COMPAT_DATA_PATH environment variable for Epic Games Launcher
+    export STEAM_COMPAT_DATA_PATH="$HOME/.local/share/Steam/steamapps/compatdata/${appid}"
+
+    # Download EXE file
+    if [ ! -f "$exe_file" ]; then
+        echo "Downloading EXE file"
+        wget $exe_url -O $exe_file
+    fi
+
+    # Run the EXE file using Proton without the /passive option
+    echo "Running EXE file using Proton without the /passive option"
+    "$STEAM_RUNTIME" "$proton_dir/proton" run "$exe_file" &
+
+    echo "45"
+    echo "# Downloading & Installing Gog Galaxy...Please wait..."
+
+    # Cancel & Exit the GOG Galaxy Setup Wizard
+    while true; do
+        if pgrep -f "GalaxySetup.tmp" > /dev/null; then
+            pkill -f "GalaxySetup.tmp"
+            break
+        fi
+        sleep 1
+    done
+
+    # Navigate to %LocalAppData%\Temp
+    cd "$HOME/.local/share/Steam/steamapps/compatdata/$appid/pfx/drive_c/users/steamuser/Temp"
+
+    # Find the GalaxyInstaller_XXXXX folder and copy it to C:\Downloads
+    galaxy_installer_folder=$(find . -maxdepth 1 -type d -name "GalaxyInstaller_*" | head -n1)
+    cp -r "$galaxy_installer_folder" ~/Downloads/NonSteamLaunchersInstallation/
+
+    # Navigate to the C:\Downloads\GalaxyInstaller_XXXXX folder
+    cd ~/Downloads/NonSteamLaunchersInstallation/"$(basename $galaxy_installer_folder)"
+
+    # Run GalaxySetup.exe with the /VERYSILENT and /NORESTART options
+    echo "Running GalaxySetup.exe with the /VERYSILENT and /NORESTART options"
+    "$STEAM_RUNTIME" "$proton_dir/proton" run GalaxySetup.exe /VERYSILENT /NORESTART
+
+    # Wait for the EXE file to finish running
+    wait
+else
+    # Gog Galaxy Launcher is already installed
+    echo "Gog Galaxy Launcher is already installed"
 fi
-
-
 
 wait
 echo "50"
 echo "# Downloading & Installing Uplay ...please wait..."
 
-
 # Check if user selected Uplay
 if [[ $options == *"Uplay"* ]]; then
     # User selected Uplay
     echo "User selected Uplay"
-
-
-
 
     # Set the appid for the Ubisoft Launcher
     if [ "$use_separate_appids" = true ]; then
@@ -1802,11 +1656,10 @@ if [[ $options == *"Uplay"* ]]; then
     cd $proton_dir
 
     # Set the STEAM_COMPAT_CLIENT_INSTALL_PATH environment variable
-    export STEAM_COMPAT_CLIENT_INSTALL_PATH="~/.local/share/Steam"
+    export STEAM_COMPAT_CLIENT_INSTALL_PATH="$HOME/.local/share/Steam"
 
     # Set the STEAM_COMPAT_DATA_PATH environment variable for Epic Games Launcher
-    export STEAM_COMPAT_DATA_PATH=~/.local/share/Steam/steamapps/compatdata/$appid
-
+    export STEAM_COMPAT_DATA_PATH="$HOME/.local/share/Steam/steamapps/compatdata/${appid}"
 
     # Download UBI file
     if [ ! -f "$ubi_file" ]; then
@@ -1824,13 +1677,10 @@ wait
 echo "60"
 echo "# Downloading & Installing Origin...please wait..."
 
-
-
 # Check if user selected Origin
 if [[ $options == *"Origin"* ]]; then
     # User selected Origin
     echo "User selected Origin"
-
 
     # Set the appid for the Origin Launcher
     if [ "$use_separate_appids" = true ]; then
@@ -1848,11 +1698,10 @@ if [[ $options == *"Origin"* ]]; then
     cd $proton_dir
 
     # Set the STEAM_COMPAT_CLIENT_INSTALL_PATH environment variable
-    export STEAM_COMPAT_CLIENT_INSTALL_PATH="~/.local/share/Steam"
+    export STEAM_COMPAT_CLIENT_INSTALL_PATH="$HOME/.local/share/Steam"
 
     # Set the STEAM_COMPAT_DATA_PATH environment variable for Epic Games Launcher
-    export STEAM_COMPAT_DATA_PATH=~/.local/share/Steam/steamapps/compatdata/$appid
-
+    export STEAM_COMPAT_DATA_PATH="$HOME/.local/share/Steam/steamapps/compatdata/${appid}"
 
     # Download ORIGIN file
     if [ ! -f "$origin_file" ]; then
@@ -1871,7 +1720,7 @@ if [[ $options == *"Origin"* ]]; then
     pkill Origin.exe
 
     # Download version.dll file
-    if [ ! -f "~/Downloads/NonSteamLaunchersInstallation/version.dll" ]; then
+    if [ ! -f "$HOME/Downloads/NonSteamLaunchersInstallation/version.dll" ]; then
         echo "Downloading version.dll file"
         wget https://github.com/p0358/Fuck_off_EA_App/releases/download/v2/version.dll -O ~/Downloads/NonSteamLaunchersInstallation/version.dll
     fi
@@ -1880,10 +1729,8 @@ if [[ $options == *"Origin"* ]]; then
     echo "Moving version.dll file to desired location"
     mv ~/Downloads/NonSteamLaunchersInstallation/version.dll "$HOME/.local/share/Steam/steamapps/compatdata/$appid/pfx/drive_c/Program Files (x86)/Origin/"
 
-
     # Wait for the ORIGIN file to finish running
     wait
-
 fi
 
 wait
@@ -1894,8 +1741,6 @@ echo "# Downloading & Installing Battle.net...please wait..."
 if [[ $options == *"Battle.net"* ]]; then
     # User selected Battle.net
     echo "User selected Battle.net"
-
-
 
     # Set the appid for the Battlenet Launcher
     if [ "$use_separate_appids" = true ]; then
@@ -1913,22 +1758,20 @@ if [[ $options == *"Battle.net"* ]]; then
     cd $proton_dir
 
     # Set the STEAM_COMPAT_CLIENT_INSTALL_PATH environment variable
-    export STEAM_COMPAT_CLIENT_INSTALL_PATH="~/.local/share/Steam"
+    export STEAM_COMPAT_CLIENT_INSTALL_PATH="$HOME/.local/share/Steam"
 
     # Set the STEAM_COMPAT_DATA_PATH environment variable for Epic Games Launcher
-    export STEAM_COMPAT_DATA_PATH=~/.local/share/Steam/steamapps/compatdata/$appid
+    export STEAM_COMPAT_DATA_PATH="$HOME/.local/share/Steam/steamapps/compatdata/${appid}"
 
-
-      # Download BATTLE file
+    # Download BATTLE file
     if [ ! -f "$battle_file" ]; then
         echo "Downloading BATTLE file"
         wget $battle_url -O $battle_file
     fi
 
     # Run the BATTLE file using Proton with the /passive option
-        echo "Running BATTLE file using Proton with the /passive option"
-        "$STEAM_RUNTIME" "$proton_dir/proton" run "$battle_file" Battle.net-Setup.exe --lang=enUS --installpath="C:\Program Files (x86)\Battle.net"
-
+    echo "Running BATTLE file using Proton with the /passive option"
+    "$STEAM_RUNTIME" "$proton_dir/proton" run "$battle_file" Battle.net-Setup.exe --lang=enUS --installpath="C:\Program Files (x86)\Battle.net"
 fi
 
 wait
@@ -1940,9 +1783,6 @@ echo "# Downloading & Installing Amazon Games...please wait..."
 if [[ $options == *"Amazon Games"* ]]; then
     # User selected Amazon Games
     echo "User selected Amazon Games"
-
-
-
 
     # Set the appid for the Amazon Games Launcher
     if [ "$use_separate_appids" = true ]; then
@@ -1960,11 +1800,10 @@ if [[ $options == *"Amazon Games"* ]]; then
     cd $proton_dir
 
     # Set the STEAM_COMPAT_CLIENT_INSTALL_PATH environment variable
-    export STEAM_COMPAT_CLIENT_INSTALL_PATH="~/.local/share/Steam"
+    export STEAM_COMPAT_CLIENT_INSTALL_PATH="$HOME/.local/share/Steam"
 
     # Set the STEAM_COMPAT_DATA_PATH environment variable for Amazon Games Launcher
-    export STEAM_COMPAT_DATA_PATH=~/.local/share/Steam/steamapps/compatdata/$appid
-
+    export STEAM_COMPAT_DATA_PATH="$HOME/.local/share/Steam/steamapps/compatdata/${appid}"
 
     # Download Amazon file
     if [ ! -f "$amazon_file" ]; then
@@ -1972,27 +1811,21 @@ if [[ $options == *"Amazon Games"* ]]; then
         wget $amazon_url -O $amazon_file
     fi
 
-
     # Run the Amazon file using Proton with the /passive option
     echo "Running Amazon file using Proton with the /passive option"
-    "$STEAM_RUNTIME" "$proton_dir/proton" run "$amazon_file" &
-
+    "$STEAM_RUNTIME" "${proton_dir}/proton" run "$amazon_file" &
 
     while true; do
-    if pgrep -f "Amazon Games.exe" > /dev/null; then
-        pkill -f "Amazon Games.exe"
-        break
-    fi
-    sleep 1
-done
+        if pgrep -f "Amazon Games.exe" > /dev/null; then
+            pkill -f "Amazon Games.exe"
+            break
+        fi
+        sleep 1
+    done
 
     # Wait for the Amazon file to finish running
     wait
 fi
-
-
-
-
 
 wait
 
@@ -2003,8 +1836,6 @@ echo "# Downloading & Installing EA App...please wait..."
 if [[ $options == *"EA App"* ]]; then
     # User selected EA App
     echo "User selected EA App"
-
-
 
     # Set the appid for the EA App Launcher
     if [ "$use_separate_appids" = true ]; then
@@ -2022,11 +1853,10 @@ if [[ $options == *"EA App"* ]]; then
     cd $proton_dir
 
     # Set the STEAM_COMPAT_CLIENT_INSTALL_PATH environment variable
-    export STEAM_COMPAT_CLIENT_INSTALL_PATH="~/.local/share/Steam"
+    export STEAM_COMPAT_CLIENT_INSTALL_PATH="$HOME/.local/share/Steam"
 
     # Set the STEAM_COMPAT_DATA_PATH environment variable for Epic Games Launcher
-    export STEAM_COMPAT_DATA_PATH=~/.local/share/Steam/steamapps/compatdata/$appid
-
+    export STEAM_COMPAT_DATA_PATH="$HOME/.local/share/Steam/steamapps/compatdata/${appid}"
 
     # Download EA App file
     if [ ! -f "$eaapp_file" ]; then
@@ -2034,23 +1864,22 @@ if [[ $options == *"EA App"* ]]; then
         wget $eaapp_url -O $eaapp_file
     fi
 
-
     # Run the EA App file using Proton with the /passive option
     echo "Running EA App file using Proton with the /passive option"
     "$STEAM_RUNTIME" "$proton_dir/proton" run "$eaapp_file" /quiet
 
     counter=0
-while true; do
-    if pgrep -f "EABackgroundService.exe" > /dev/null; then
-        pkill -f "EABackgroundService.exe"
-        break
-    fi
-    sleep 1
-    counter=$((counter + 1))
-    if [ $counter -ge 10 ]; then
-        break
-    fi
-done
+    while true; do
+        if pgrep -f "EABackgroundService.exe" > /dev/null; then
+            pkill -f "EABackgroundService.exe"
+            break
+        fi
+        sleep 1
+        counter=$((counter + 1))
+        if [ $counter -ge 10 ]; then
+            break
+        fi
+    done
 
     # Wait for the EA App file to finish running
     wait
@@ -2064,8 +1893,6 @@ echo "# Downloading & Installing itch.io...please wait..."
 if [[ $options == *"itch.io"* ]]; then
     # User selected itchio Launcher
     echo "User selected itch.io"
-
-
 
     # Set the appid for the itchio Launcher
     if [ "$use_separate_appids" = true ]; then
@@ -2083,11 +1910,10 @@ if [[ $options == *"itch.io"* ]]; then
     cd $proton_dir
 
     # Set the STEAM_COMPAT_CLIENT_INSTALL_PATH environment variable
-    export STEAM_COMPAT_CLIENT_INSTALL_PATH="~/.local/share/Steam"
+    export STEAM_COMPAT_CLIENT_INSTALL_PATH="$HOME/.local/share/Steam"
 
     # Set the STEAM_COMPAT_DATA_PATH environment variable for Epic Games Launcher
-    export STEAM_COMPAT_DATA_PATH=~/.local/share/Steam/steamapps/compatdata/$appid
-
+    export STEAM_COMPAT_DATA_PATH="$HOME/.local/share/Steam/steamapps/compatdata/${appid}"
 
     # Download itchio file
     if [ ! -f "$itchio_file" ]; then
@@ -2109,7 +1935,6 @@ if [[ $options == *"Legacy Games"* ]]; then
     # User selected Legacy Games
     echo "User selected Legacy Games"
 
-
     # Set the appid for the Legacy Games Launcher
     if [ "$use_separate_appids" = true ]; then
         appid=LegacyGamesLauncher
@@ -2126,11 +1951,10 @@ if [[ $options == *"Legacy Games"* ]]; then
     cd $proton_dir
 
     # Set the STEAM_COMPAT_CLIENT_INSTALL_PATH environment variable
-    export STEAM_COMPAT_CLIENT_INSTALL_PATH="~/.local/share/Steam"
+    export STEAM_COMPAT_CLIENT_INSTALL_PATH="$HOME/.local/share/Steam"
 
     # Set the STEAM_COMPAT_DATA_PATH environment variable for Legacy Games Launcher
-    export STEAM_COMPAT_DATA_PATH=~/.local/share/Steam/steamapps/compatdata/$appid
-
+    export STEAM_COMPAT_DATA_PATH="$HOME/.local/share/Steam/steamapps/compatdata/${appid}"
 
     # Download Legacy file
     if [ ! -f "$legacygames_file" ]; then
@@ -2138,13 +1962,13 @@ if [[ $options == *"Legacy Games"* ]]; then
         wget $legacygames_url -O $legacygames_file
     fi
 
-      # Run the Legacy file using Proton with the /passive option
-      echo "Running Legacy file using Proton with the /passive option"
-      "$STEAM_RUNTIME" "$proton_dir/proton" run "$legacygames_file" /S
+    # Run the Legacy file using Proton with the /passive option
+    echo "Running Legacy file using Proton with the /passive option"
+    "$STEAM_RUNTIME" "$proton_dir/proton" run "$legacygames_file" /S
 fi
+
 # Wait for the Legacy file to finish running
 wait
-
 
 echo "91"
 echo "# Downloading & Installing Humble Games Collection...please wait..."
@@ -2171,42 +1995,37 @@ if [[ $options == *"Humble Games Collection"* ]]; then
         wget https://raw.githubusercontent.com/moraroy/NonSteamLaunchers-On-Steam-Deck/main/humble-app/start-humble.cmd -O "$HOME/.local/share/Steam/steamapps/compatdata/$appid/pfx/start-humble.cmd"
     fi
 
+    # Set the appid for the Humble Games Launcher
+    if [ "$use_separate_appids" = true ]; then
+        appid=HumbleGamesLauncher
+    else
+        appid=NonSteamLaunchers
+    fi
 
-        # Set the appid for the Humble Games Launcher
-        if [ "$use_separate_appids" = true ]; then
-            appid=HumbleGamesLauncher
-        else
-            appid=NonSteamLaunchers
-        fi
+    # Create app id folder in compatdata folder if it doesn't exist
+    if [ ! -d "$HOME/.local/share/Steam/steamapps/compatdata/$appid" ]; then
+        mkdir -p "$HOME/.local/share/Steam/steamapps/compatdata/$appid"
+    fi
 
+    # Change working directory to Proton's
+    cd $proton_dir
 
-        # Create app id folder in compatdata folder if it doesn't exist
-        if [ ! -d "$HOME/.local/share/Steam/steamapps/compatdata/$appid" ]; then
-            mkdir -p "$HOME/.local/share/Steam/steamapps/compatdata/$appid"
-        fi
+    # Set the STEAM_COMPAT_CLIENT_INSTALL_PATH environment variable
+    export STEAM_COMPAT_CLIENT_INSTALL_PATH="$HOME/.local/share/Steam"
 
-        # Change working directory to Proton's
-        cd $proton_dir
+    # Set the STEAM_COMPAT_DATA_PATH environment variable for Humble Games Launcher
+    export STEAM_COMPAT_DATA_PATH="$HOME/.local/share/Steam/steamapps/compatdata/${appid}"
 
-        # Set the STEAM_COMPAT_CLIENT_INSTALL_PATH environment variable
-        export STEAM_COMPAT_CLIENT_INSTALL_PATH="~/.local/share/Steam"
+    # Download exe file
+    if [ ! -f "$humblegames_file" ]; then
+        echo "Downloading MSI file"
+        wget $humblegames_url -O $humblegames_file
+    fi
 
-        # Set the STEAM_COMPAT_DATA_PATH environment variable for Humble Games Launcher
-        export STEAM_COMPAT_DATA_PATH=~/.local/share/Steam/steamapps/compatdata/$appid
-
-
-        # Download exe file
-        if [ ! -f "$humblegames_file" ]; then
-            echo "Downloading MSI file"
-            wget $humblegames_url -O $humblegames_file
-        fi
-
-        # Run the exe file using Proton with the /passive option
-        echo "Running Exe file using Proton with the /passive option"
-        "$STEAM_RUNTIME" "$proton_dir/proton" run "$humblegames_file" /S /D="C:\Program Files\Humble App"
-
+    # Run the exe file using Proton with the /passive option
+    echo "Running Exe file using Proton with the /passive option"
+    "$STEAM_RUNTIME" "$proton_dir/proton" run "$humblegames_file" /S /D="C:\Program Files\Humble App"
 fi
-
 
 wait
 echo "92"
@@ -2216,7 +2035,6 @@ echo "# Downloading & Installing Indie Gala...please wait..."
 if [[ $options == *"IndieGala"* ]]; then
     # User selected indiegala
     echo "User selected IndieGala"
-
 
     # Set the appid for the indiegala Launcher
     if [ "$use_separate_appids" = true ]; then
@@ -2234,11 +2052,10 @@ if [[ $options == *"IndieGala"* ]]; then
     cd $proton_dir
 
     # Set the STEAM_COMPAT_CLIENT_INSTALL_PATH environment variable
-    export STEAM_COMPAT_CLIENT_INSTALL_PATH="~/.local/share/Steam"
+    export STEAM_COMPAT_CLIENT_INSTALL_PATH="$HOME/.local/share/Steam"
 
     # Set the STEAM_COMPAT_DATA_PATH environment variable for Legacy Games Launcher
-    export STEAM_COMPAT_DATA_PATH=~/.local/share/Steam/steamapps/compatdata/$appid
-
+    export STEAM_COMPAT_DATA_PATH="$HOME/.local/share/Steam/steamapps/compatdata/${appid}"
 
     # Download indiegala file
     if [ ! -f "$indiegala_file" ]; then
@@ -2250,9 +2067,9 @@ if [[ $options == *"IndieGala"* ]]; then
       echo "Running IndieGala file using Proton with the /passive option"
       "$STEAM_RUNTIME" "$proton_dir/proton" run "$indiegala_file" /S
 fi
+
 # Wait for the Indie file to finish running
 wait
-
 
 echo "93"
 echo "# Downloading & Installing Rockstar Games Launcher...please wait..."
@@ -2262,41 +2079,40 @@ if [[ $options == *"Rockstar Games Launcher"* ]]; then
     # User selected rockstar games
     echo "User selected Rockstar Games Launcher"
 
-        # Set the appid for the indiegala Launcher
-        if [ "$use_separate_appids" = true ]; then
-            appid=RockstarGamesLauncher
-        else
-            appid=NonSteamLaunchers
-        fi
+    # Set the appid for the indiegala Launcher
+    if [ "$use_separate_appids" = true ]; then
+        appid=RockstarGamesLauncher
+    else
+        appid=NonSteamLaunchers
+    fi
 
-        # Create app id folder in compatdata folder if it doesn't exist
-        if [ ! -d "$HOME/.local/share/Steam/steamapps/compatdata/$appid" ]; then
-            mkdir -p "$HOME/.local/share/Steam/steamapps/compatdata/$appid"
-        fi
+    # Create app id folder in compatdata folder if it doesn't exist
+    if [ ! -d "$HOME/.local/share/Steam/steamapps/compatdata/$appid" ]; then
+        mkdir -p "$HOME/.local/share/Steam/steamapps/compatdata/$appid"
+    fi
 
-        # Change working directory to Proton's
-        cd $proton_dir
+    # Change working directory to Proton's
+    cd $proton_dir
 
-        # Set the STEAM_COMPAT_CLIENT_INSTALL_PATH environment variable
-        export STEAM_COMPAT_CLIENT_INSTALL_PATH="~/.local/share/Steam"
+    # Set the STEAM_COMPAT_CLIENT_INSTALL_PATH environment variable
+    export STEAM_COMPAT_CLIENT_INSTALL_PATH="$HOME/.local/share/Steam"
 
-        # Set the STEAM_COMPAT_DATA_PATH environment variable for Legacy Games Launcher
-        export STEAM_COMPAT_DATA_PATH=~/.local/share/Steam/steamapps/compatdata/$appid
+    # Set the STEAM_COMPAT_DATA_PATH environment variable for Legacy Games Launcher
+    export STEAM_COMPAT_DATA_PATH="$HOME/.local/share/Steam/steamapps/compatdata/${appid}"
 
-        # Download rockstar games file
-        if [ ! -f "$rockstar_file" ]; then
-            echo "Downloading rockstar file"
-            wget $rockstar_url -O $rockstar_file
-        fi
+    # Download rockstar games file
+    if [ ! -f "$rockstar_file" ]; then
+        echo "Downloading rockstar file"
+        wget $rockstar_url -O $rockstar_file
+    fi
 
-          # Run the rockstar file using Proton with the /passive option
-          echo "Running Rockstar Games Launcher file using Proton with the /passive option"
-          "$STEAM_RUNTIME" "$proton_dir/proton" run "$rockstar_file"
-
+    # Run the rockstar file using Proton with the /passive option
+    echo "Running Rockstar Games Launcher file using Proton with the /passive option"
+    "$STEAM_RUNTIME" "$proton_dir/proton" run "$rockstar_file"
 fi
+
 # Wait for the rockstar file to finish running
 wait
-
 
 echo "94"
 echo "# Downloading & Installing Glyph Launcher...please wait..."
@@ -2306,43 +2122,40 @@ if [[ $options == *"Glyph Launcher"* ]]; then
     # User selected Glyph
     echo "User selected Glyph Launcher"
 
-        # Set the appid for Glyph
-        if [ "$use_separate_appids" = true ]; then
-            appid=GlyphLauncher
-        else
-            appid=NonSteamLaunchers
-        fi
+    # Set the appid for Glyph
+    if [ "$use_separate_appids" = true ]; then
+        appid=GlyphLauncher
+    else
+        appid=NonSteamLaunchers
+    fi
 
-        # Create app id folder in compatdata folder if it doesn't exist
-        if [ ! -d "$HOME/.local/share/Steam/steamapps/compatdata/$appid" ]; then
-            mkdir -p "$HOME/.local/share/Steam/steamapps/compatdata/$appid"
-        fi
+    # Create app id folder in compatdata folder if it doesn't exist
+    if [ ! -d "$HOME/.local/share/Steam/steamapps/compatdata/$appid" ]; then
+        mkdir -p "$HOME/.local/share/Steam/steamapps/compatdata/$appid"
+    fi
 
-        # Change working directory to Proton's
-        cd $proton_dir
+    # Change working directory to Proton's
+    cd $proton_dir
 
-        # Set the STEAM_COMPAT_CLIENT_INSTALL_PATH environment variable
-        export STEAM_COMPAT_CLIENT_INSTALL_PATH="~/.local/share/Steam"
+    # Set the STEAM_COMPAT_CLIENT_INSTALL_PATH environment variable
+    export STEAM_COMPAT_CLIENT_INSTALL_PATH="$HOME/.local/share/Steam"
 
-        # Set the STEAM_COMPAT_DATA_PATH environment variable for Legacy Games Launcher
-        export STEAM_COMPAT_DATA_PATH=~/.local/share/Steam/steamapps/compatdata/$appid
+    # Set the STEAM_COMPAT_DATA_PATH environment variable for Legacy Games Launcher
+    export STEAM_COMPAT_DATA_PATH="$HOME/.local/share/Steam/steamapps/compatdata/${appid}"
 
-        # Download Glyph file
-        if [ ! -f "$glyph_file" ]; then
-            echo "Downloading Glyph file"
-            wget $glyph_url -O $glyph_file
-        fi
+    # Download Glyph file
+    if [ ! -f "$glyph_file" ]; then
+        echo "Downloading Glyph file"
+        wget $glyph_url -O $glyph_file
+    fi
 
-          # Run the Glyph file using Proton with the /passive option
-          echo "Running Glyph Launcher file using Proton with the /passive option"
-          "$STEAM_RUNTIME" "$proton_dir/proton" run "$glyph_file"
-
+    # Run the Glyph file using Proton with the /passive option
+    echo "Running Glyph Launcher file using Proton with the /passive option"
+    "$STEAM_RUNTIME" "$proton_dir/proton" run "$glyph_file"
 fi
+
 # Wait for the Glyph file to finish running
 wait
-
-
-
 
 echo "95"
 echo "# Downloading & Installing Minecraft Launcher...please wait..."
@@ -2362,45 +2175,42 @@ if [[ $options == *"Minecraft"* ]]; then
     # Set MinecraftLauncher.exe Variable
     minecraftinstall_path="$HOME/.local/share/Steam/steamapps/compatdata/$appid/pfx/drive_c/Program Files (x86)/Minecraft Launcher/MinecraftLauncher.exe"
 
+    # Create app id folder in compatdata folder if it doesn't exist
+    if [ ! -d "$HOME/.local/share/Steam/steamapps/compatdata/$appid" ]; then
+        mkdir -p "$HOME/.local/share/Steam/steamapps/compatdata/$appid"
+    fi
 
-        # Create app id folder in compatdata folder if it doesn't exist
-        if [ ! -d "$HOME/.local/share/Steam/steamapps/compatdata/$appid" ]; then
-            mkdir -p "$HOME/.local/share/Steam/steamapps/compatdata/$appid"
-        fi
+    # Change working directory to Proton's
+    cd $proton_dir
 
-        # Change working directory to Proton's
-        cd $proton_dir
+    # Set the STEAM_COMPAT_CLIENT_INSTALL_PATH environment variable
+    export STEAM_COMPAT_CLIENT_INSTALL_PATH="$HOME/.local/share/Steam"
 
-        # Set the STEAM_COMPAT_CLIENT_INSTALL_PATH environment variable
-        export STEAM_COMPAT_CLIENT_INSTALL_PATH="~/.local/share/Steam"
+    # Set the STEAM_COMPAT_DATA_PATH environment variable for Legacy Games Launcher
+    export STEAM_COMPAT_DATA_PATH="$HOME/.local/share/Steam/steamapps/compatdata/${appid}"
 
-        # Set the STEAM_COMPAT_DATA_PATH environment variable for Legacy Games Launcher
-        export STEAM_COMPAT_DATA_PATH=~/.local/share/Steam/steamapps/compatdata/$appid
+    # Download Minecraft file
+    if [ ! -f "$minecraft_file" ]; then
+        echo "Downloading Minecraft file"
+        wget $minecraft_url -O $minecraft_file
+    fi
 
-        # Download Minecraft file
-        if [ ! -f "$minecraft_file" ]; then
-            echo "Downloading Minecraft file"
-            wget $minecraft_url -O $minecraft_file
-        fi
+    # Run the Minecraft file using Proton with the /passive option
+    echo "Running Minecraft Launcher file using Proton with the /passive option"
+    "$STEAM_RUNTIME" "$proton_dir/proton" run MsiExec.exe /i "$minecraft_file" /q
 
-          # Run the Minecraft file using Proton with the /passive option
-          echo "Running Minecraft Launcher file using Proton with the /passive option"
-          "$STEAM_RUNTIME" "$proton_dir/proton" run MsiExec.exe /i "$minecraft_file" /q
+    if [ -f "$minecraftinstall_path" ]; then
+        # Run MinecraftLauncher.exe for the first time
+        "$STEAM_RUNTIME" "$proton_dir/proton" run "$minecraftinstall_path"
+    else
+        echo "Could not find MinecraftLauncher.exe at $minecraftinstall_path"
+    fi
 
-          if [ -f "$minecraftinstall_path" ]; then
-              # Run MinecraftLauncher.exe for the first time
-              "$STEAM_RUNTIME" "$proton_dir/proton" run "$minecraftinstall_path"
-          else
-              echo "Could not find MinecraftLauncher.exe at $minecraftinstall_path"
-          fi
-
-        echo "Minecraft is already installed at $minecraftinstall_path"
-
+    echo "Minecraft is already installed at $minecraftinstall_path"
 fi
 
 # Wait for the Minecraft file to finish running
 wait
-
 
 echo "96"
 echo "# Downloading & Installing Playstation Plus...please wait..."
@@ -2410,47 +2220,39 @@ if [[ $options == *"Playstation Plus"* ]]; then
     # User selected PlayStation Plus Launcher
     echo "User selected PlayStation Plus"
 
+    # Set the appid for the PlayStation Plus Launcher
+    if [ "$use_separate_appids" = true ]; then
+    appid=PlaystationPlusLauncher
+    else
+    appid=NonSteamLaunchers
+    fi
 
-        # Set the appid for the PlayStation Plus Launcher
-        if [ "$use_separate_appids" = true ]; then
-        appid=PlaystationPlusLauncher
-        else
-        appid=NonSteamLaunchers
-        fi
+    # Create app id folder in compatdata folder if it doesn't exist
+    if [ ! -d "$HOME/.local/share/Steam/steamapps/compatdata/$appid" ]; then
+        mkdir -p "$HOME/.local/share/Steam/steamapps/compatdata/$appid"
+    fi
 
+    # Change working directory to Proton's
+    cd $proton_dir
 
-        # Create app id folder in compatdata folder if it doesn't exist
-        if [ ! -d "$HOME/.local/share/Steam/steamapps/compatdata/$appid" ]; then
-            mkdir -p "$HOME/.local/share/Steam/steamapps/compatdata/$appid"
-        fi
+    # Set the STEAM_COMPAT_CLIENT_INSTALL_PATH environment variable
+    export STEAM_COMPAT_CLIENT_INSTALL_PATH="$HOME/.local/share/Steam"
 
-        # Change working directory to Proton's
-        cd $proton_dir
+    # Set the STEAM_COMPAT_DATA_PATH environment variable for Epic Games Launcher
+    export STEAM_COMPAT_DATA_PATH="$HOME/.local/share/Steam/steamapps/compatdata/${appid}"
 
-        # Set the STEAM_COMPAT_CLIENT_INSTALL_PATH environment variable
-        export STEAM_COMPAT_CLIENT_INSTALL_PATH="~/.local/share/Steam"
+    # Download MSI file
+    if [ ! -f "$psplus_file" ]; then
+        echo "Downloading MSI file"
+        wget $psplus_url -O $psplus_file
+    fi
 
-        # Set the STEAM_COMPAT_DATA_PATH environment variable for Epic Games Launcher
-        export STEAM_COMPAT_DATA_PATH=~/.local/share/Steam/steamapps/compatdata/$appid
-
-
-        # Download MSI file
-        if [ ! -f "$psplus_file" ]; then
-            echo "Downloading MSI file"
-            wget $psplus_url -O $psplus_file
-        fi
-
-        # Run the Playstation file using Proton with the /passive option
-        echo "Running Playstation file using Proton with the /passive option"
-        "$STEAM_RUNTIME" "$proton_dir/proton" run "$psplus_file" /q
-
+    # Run the Playstation file using Proton with the /passive option
+    echo "Running Playstation file using Proton with the /passive option"
+    "$STEAM_RUNTIME" "$proton_dir/proton" run "$psplus_file" /q
 fi
 
 wait
-
-
-
-
 
 echo "97"
 echo "# Downloading & Installing DMM Games...please wait..."
@@ -2460,57 +2262,37 @@ if [[ $options == *"DMM Games"* ]]; then
     # User selected DMM Games Launcher
     echo "User selected DMM Games"
 
+    # Set the appid for the DMM Games Launcher
+    if [ "$use_separate_appids" = true ]; then
+    appid=DMMGameLauncher
+    else
+    appid=NonSteamLaunchers
+    fi
 
-        # Set the appid for the DMM Games Launcher
-        if [ "$use_separate_appids" = true ]; then
-        appid=DMMGameLauncher
-        else
-        appid=NonSteamLaunchers
-        fi
+    # Create app id folder in compatdata folder if it doesn't exist
+    if [ ! -d "$HOME/.local/share/Steam/steamapps/compatdata/$appid" ]; then
+        mkdir -p "$HOME/.local/share/Steam/steamapps/compatdata/$appid"
+    fi
 
+    # Change working directory to Proton's
+    cd $proton_dir
 
-        # Create app id folder in compatdata folder if it doesn't exist
-        if [ ! -d "$HOME/.local/share/Steam/steamapps/compatdata/$appid" ]; then
-            mkdir -p "$HOME/.local/share/Steam/steamapps/compatdata/$appid"
-        fi
+    # Set the STEAM_COMPAT_CLIENT_INSTALL_PATH environment variable
+    export STEAM_COMPAT_CLIENT_INSTALL_PATH="$HOME/.local/share/Steam"
 
-        # Change working directory to Proton's
-        cd $proton_dir
+    # Set the STEAM_COMPAT_DATA_PATH environment variable for Epic Games Launcher
+    export STEAM_COMPAT_DATA_PATH="$HOME/.local/share/Steam/steamapps/compatdata/${appid}"
 
-        # Set the STEAM_COMPAT_CLIENT_INSTALL_PATH environment variable
-        export STEAM_COMPAT_CLIENT_INSTALL_PATH="~/.local/share/Steam"
+    # Download DMM file
+    if [ ! -f "$dmm_file" ]; then
+        echo "Downloading DMM file"
+        wget $dmm_url -O $dmm_file
+    fi
 
-        # Set the STEAM_COMPAT_DATA_PATH environment variable for Epic Games Launcher
-        export STEAM_COMPAT_DATA_PATH=~/.local/share/Steam/steamapps/compatdata/$appid
-
-
-        # Download DMM file
-        if [ ! -f "$dmm_file" ]; then
-            echo "Downloading DMM file"
-            wget $dmm_url -O $dmm_file
-        fi
-
-        # Run the DMM file using Proton with the /passive option
-        echo "Running DMM file using Proton with the /passive option"
-        "$STEAM_RUNTIME" "$proton_dir/proton" run "$dmm_file" /q
-
+    # Run the DMM file using Proton with the /passive option
+    echo "Running DMM file using Proton with the /passive option"
+    "$STEAM_RUNTIME" "$proton_dir/proton" run "$dmm_file" /q
 fi
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 echo "99"
 echo "# Checking if Chrome is installed...please wait..."
@@ -2536,18 +2318,11 @@ if [[ $options == *"Netflix"* ]] || [[ $options == *"Xbox Game Pass"* ]] || [[ $
     fi
 fi
 
-#wait for Google Chrome to finish
+# wait for Google Chrome to finish
 wait
 
-
-
-
-
 # Delete NonSteamLaunchersInstallation subfolder in Downloads folder
-rm -rf ~/Downloads/NonSteamLaunchersInstallation
-
-
-
+rm -rf "$HOME/Downloads/NonSteamLaunchersInstallation"
 
     echo "100"
     echo "# Installation Complete - Steam will now restart. Your launchers will be in your library!...Food for thought...do Jedis use Force Compatability?"
@@ -2559,20 +2334,7 @@ zenity --progress \
 
 wait
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-#Checking Files For Shortcuts and Setting Directories For Shortcuts
+# Checking Files For Shortcuts and Setting Directories For Shortcuts
 if [[ -f "$epic_games_launcher_path1" ]]; then
     # Epic Games Launcher is installed at path 1
     epicshortcutdirectory="\"$epic_games_launcher_path1\""
@@ -2584,6 +2346,7 @@ elif [[ -f "$epic_games_launcher_path2" ]]; then
     epiclaunchoptions="STEAM_COMPAT_DATA_PATH=\"$HOME/.local/share/Steam/steamapps/compatdata/EpicGamesLauncher/\" %command%"
     epicstartingdir="\"$(dirname "$epic_games_launcher_path2")\""
 fi
+
 if [[ -f "$gog_galaxy_path1" ]]; then
     # Gog Galaxy Launcher is installed at path 1
     gogshortcutdirectory="\"$gog_galaxy_path1\""
@@ -2595,6 +2358,7 @@ elif [[ -f "$gog_galaxy_path2" ]]; then
     goglaunchoptions="STEAM_COMPAT_DATA_PATH=\"$HOME/.local/share/Steam/steamapps/compatdata/GogGalaxyLauncher/\" %command%"
     gogstartingdir="\"$(dirname "$gog_galaxy_path2")\""
 fi
+
 if [[ -f "$origin_path1" ]]; then
     # Origin Launcher is installed at path 1
     originshortcutdirectory="\"$origin_path1\""
@@ -2606,6 +2370,7 @@ elif [[ -f "$origin_path2" ]]; then
     originlaunchoptions="STEAM_COMPAT_DATA_PATH=\"$HOME/.local/share/Steam/steamapps/compatdata/OriginLauncher/\" %command%"
     originstartingdir="\"$(dirname "$origin_path2")\""
 fi
+
 if [[ -f "$uplay_path1" ]]; then
     # Uplay Launcher is installed at path 1
     uplayshortcutdirectory="\"$uplay_path1\""
@@ -2617,6 +2382,7 @@ elif [[ -f "$uplay_path2" ]]; then
     uplaylaunchoptions="STEAM_COMPAT_DATA_PATH=\"$HOME/.local/share/Steam/steamapps/compatdata/UplayLauncher/\" %command%"
     uplaystartingdir="\"$(dirname "$uplay_path2")\""
 fi
+
 if [[ -f "$battlenet_path1" ]]; then
     # Battlenet Launcher is installed at path 1
     battlenetshortcutdirectory="\"$battlenet_path1\""
@@ -2628,6 +2394,7 @@ elif [[ -f "$battlenet_path2" ]]; then
     battlenetlaunchoptions="STEAM_COMPAT_DATA_PATH=\"$HOME/.local/share/Steam/steamapps/compatdata/Battle.netLauncher/\" %command%"
     battlenetstartingdir="\"$(dirname "$battlenet_path2")\""
 fi
+
 if [[ -f "$eaapp_path1" ]]; then
     # EA App Launcher is installed at path 1
     eaappshortcutdirectory="\"$eaapp_path1\""
@@ -2639,6 +2406,7 @@ elif [[ -f "$eaapp_path2" ]]; then
     eaapplaunchoptions="STEAM_COMPAT_DATA_PATH=\"$HOME/.local/share/Steam/steamapps/compatdata/TheEAappLauncher/\" %command%"
     eaappstartingdir="\"$(dirname "$eaapp_path2")\""
 fi
+
 if [[ -f "$amazongames_path1" ]]; then
     # Amazon Games Launcher is installed at path 1
     amazonshortcutdirectory="\"$amazongames_path1\""
@@ -2650,6 +2418,7 @@ elif [[ -f "$amazongames_path2" ]]; then
     amazonlaunchoptions="STEAM_COMPAT_DATA_PATH=\"$HOME/.local/share/Steam/steamapps/compatdata/AmazonGamesLauncher/\" %command%"
     amazonstartingdir="\"$(dirname "$amazongames_path2")\""
 fi
+
 if [[ -f "$itchio_path1" ]]; then
     # itchio Launcher is installed at path 1
     itchioshortcutdirectory="\"$itchio_path1\""
@@ -2661,6 +2430,7 @@ elif [[ -f "$itchio_path2" ]]; then
     itchiolaunchoptions="STEAM_COMPAT_DATA_PATH=\"$HOME/.local/share/Steam/steamapps/compatdata/itchioLauncher/\" %command%"
     itchiostartingdir="\"$(dirname "$itchio_path2")\""
 fi
+
 if [[ -f "$legacygames_path1" ]]; then
     # Legacy Games Launcher is installed at path 1
     legacyshortcutdirectory="\"$legacygames_path1\""
@@ -2672,6 +2442,7 @@ elif [[ -f "$legacygames_path2" ]]; then
     legacylaunchoptions="STEAM_COMPAT_DATA_PATH=\"$HOME/.local/share/Steam/steamapps/compatdata/LegacyGamesLauncher/\" %command%"
     legacystartingdir="\"$(dirname "$legacygames_path2")\""
 fi
+
 if [[ -f "$humblegames_path1" ]]; then
     # Humble Games Launcher is installed at path 1
     humbleshortcutdirectory="\"$humblegames_path1\""
@@ -2683,6 +2454,7 @@ elif [[ -f "$humblegames_path2" ]]; then
     humblelaunchoptions="STEAM_COMPAT_DATA_PATH=\"$HOME/.local/share/Steam/steamapps/compatdata/HumbleGamesLauncher/\" %command%"
     humblestartingdir="\"$(dirname "$humblegames_path2")\""
 fi
+
 if [[ -f "$indiegala_path1" ]]; then
     # indiegala Launcher is installed at path 1
     indieshortcutdirectory="\"$indiegala_path1\""
@@ -2694,6 +2466,7 @@ elif [[ -f "$indiegala_path2" ]]; then
     indielaunchoptions="STEAM_COMPAT_DATA_PATH=\"$HOME/.local/share/Steam/steamapps/compatdata/IndieGalaLauncher/\" %command%"
     indiestartingdir="\"$(dirname "$indiegala_path2")\""
 fi
+
 if [[ -f "$rockstar_path1" ]]; then
     # rockstar Launcher is installed at path 1
     rockstarshortcutdirectory="\"$rockstar_path1\""
@@ -2705,6 +2478,7 @@ elif [[ -f "$rockstar_path2" ]]; then
     rockstarlaunchoptions="STEAM_COMPAT_DATA_PATH=\"$HOME/.local/share/Steam/steamapps/compatdata/RockstarGamesLauncher/\" %command%"
     rockstarstartingdir="\"$(dirname "$rockstar_path2")\""
 fi
+
 if [[ -f "$glyph_path1" ]]; then
     # Glyph is installed at path 1
     glyphshortcutdirectory="\"$glyph_path1\""
@@ -2716,6 +2490,7 @@ elif [[ -f "$glyph_path2" ]]; then
     glyphlaunchoptions="STEAM_COMPAT_DATA_PATH=\"$HOME/.local/share/Steam/steamapps/compatdata/GlyphLauncher/\" %command%"
     glyphstartingdir="\"$(dirname "$glyph_path2")\""
 fi
+
 if [[ -f "$minecraft_path1" ]]; then
     # Minecraft is installed at path 1
     minecraftshortcutdirectory="\"$minecraft_path1\""
@@ -2727,6 +2502,7 @@ elif [[ -f "$minecraft_path2" ]]; then
     minecraftlaunchoptions="STEAM_COMPAT_DATA_PATH=\"$HOME/.local/share/Steam/steamapps/compatdata/MinecraftLauncher/\" %command%"
     minecraftstartingdir="\"$(dirname "$minecraft_path1")\""
 fi
+
 if [[ -f "$psplus_path1" ]]; then
     # Playstation is installed at path 1
     psplusshortcutdirectory="\"$psplus_path1\""
@@ -2738,6 +2514,7 @@ elif [[ -f "$psplus_path2" ]]; then
     pspluslaunchoptions="STEAM_COMPAT_DATA_PATH=\"$HOME/.local/share/Steam/steamapps/compatdata/PlaystationPlusLauncher/\" %command%"
     psplusstartingdir="\"$(dirname "$psplus_path2")\""
 fi
+
 if [[ -f "$dmm_path1" ]]; then
     # DMM Games is installed at path 1
     dmmshortcutdirectory="\"$dmm_path1\""
@@ -2749,8 +2526,6 @@ elif [[ -f "$dmm_path2" ]]; then
     dmmlaunchoptions="STEAM_COMPAT_DATA_PATH=\"$HOME/.local/share/Steam/steamapps/compatdata/DMMGameLauncher/\" %command%"
     dmmstartingdir="\"$(dirname "$dmm_path2")\""
 fi
-
-
 
 # Set Chrome options based on user's selection
 
@@ -2830,30 +2605,11 @@ if [ ${#custom_websites[@]} -gt 0 ]; then
         # Capitalize the first letter of the website name
         website_name="$(tr '[:lower:]' '[:upper:]' <<< "${website_name:0:1}")${website_name:1}"
 
+        # TODO: `chromelaunchoptions` is unused (SC2034)
         # Set the chromelaunchoptions variable for this website
         chromelaunchoptions="run --branch=stable --arch=x86_64 --command=/app/bin/chrome --file-forwarding com.google.Chrome @@u @@ --window-size=1280,800 --force-device-scale-factor=1.00 --device-scale-factor=1.00 --kiosk https://$clean_website/ --chrome-kiosk-type=fullscreen --no-first-run --enable-features=OverlayScrollbar"
     done
 fi
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 # Set the download directory
 download_dir=~/Downloads/NonSteamLaunchersInstallation
@@ -2873,12 +2629,6 @@ wget -P "$download_dir/lib/python$python_version/site-packages/vdf" "$download_u
 
 # Set the PYTHONPATH environment variable
 export PYTHONPATH="$download_dir/lib/python$python_version/site-packages/:$PYTHONPATH"
-
-
-
-
-
-
 
 # Set the default Steam directory
 steam_dir="$HOME/.local/share/Steam"
@@ -2901,11 +2651,9 @@ if [[ -f "$steam_dir/config/config.vdf" ]]; then
     most_recent=0
 
     # Loop through all the userdata folders
-    for USERDATA_FOLDER in ~/.steam/root/userdata/*
-    do
+    for USERDATA_FOLDER in ~/.steam/root/userdata/*; do
         # Check if the current userdata folder is not the "0" or "anonymous" folder
-        if [[ "$USERDATA_FOLDER" != *"/0" ]] && [[ "$USERDATA_FOLDER" != *"/anonymous" ]]
-        then
+        if [[ "$USERDATA_FOLDER" != *"/0" ]] && [[ "$USERDATA_FOLDER" != *"/anonymous" ]]; then
             # Get the access time of the current userdata folder
             access_time=$(stat -c %X "$USERDATA_FOLDER")
 
@@ -2913,8 +2661,7 @@ if [[ -f "$steam_dir/config/config.vdf" ]]; then
             userdata_steamid3=$(basename "$USERDATA_FOLDER")
 
             # Check if userdata_steamid3 matches steamid3 and if access time is more recent than most recent access time
-            if [[ $userdata_steamid3 -eq $steamid3 ]] && [[ $access_time -gt $most_recent ]]
-            then
+            if [[ $userdata_steamid3 -eq $steamid3 ]] && [[ $access_time -gt $most_recent ]]; then
                 # The access time of current userdata folder is more recent and steamid3 matches
                 # Set userdata_folder variable
                 userdata_folder="$USERDATA_FOLDER"
@@ -2924,7 +2671,6 @@ if [[ -f "$steam_dir/config/config.vdf" ]]; then
             fi
         fi
     done
-
 else
     echo "Could not find config.vdf file"
 fi
@@ -2958,37 +2704,24 @@ if [[ -n "$userdata_folder" ]]; then
             shortcuts_vdf_path="$config_dir/shortcuts.vdf"
         fi
     fi
-
 else
     # Userdata folder was not found
     echo "Current user's userdata folder not found"
 fi
 
-
-
-
-
-
-
-
-
 # Detach script from Steam process
 nohup sh -c 'sleep 10; /usr/bin/steam' &
 
+# TODO: should probably verify exact process name (see below)
 # Close all instances of Steam
 killall steam
 
-
+# TODO: control for exact process names (currently catches all processes with steam in name)
+# * possibly `pgrep -x steam`
 # Wait for the steam process to exit
 while pgrep steam > /dev/null; do sleep 1; done
 
-
-
-
-
-
-
-#Pre check for updating the config file
+# Pre check for updating the config file
 
 # Set the default Steam directory
 steam_dir="$HOME/.steam/root"
@@ -3008,9 +2741,6 @@ else
     echo "Could not find config.vdf file"
 fi
 
-
-
-
 # Set the path to the configset_controller_neptune.vdf file
 controller_config_path="$HOME/.local/share/Steam/steamapps/common/Steam Controller Configs/$steamid3/config/configset_controller_neptune.vdf"
 
@@ -3022,15 +2752,8 @@ else
     echo "Could not find $controller_config_path"
 fi
 
-
-
-
-
-
-
-
-
-
+# TODO: relocate to standalone python script
+# ! editorconfig will likely break this since bash uses tabs and python needs 4 spaces
 # Run the Python script to create a new entry for a Steam shortcut
 python3 -c "
 import sys
@@ -3045,8 +2768,6 @@ import re
 
 # Print the path to the file where the vdf module was loaded from
 print(vdf.__file__)
-
-
 
 # Load the shortcuts.vdf file
 with open('$shortcuts_vdf_path', 'rb') as f:
@@ -3064,7 +2785,6 @@ if isinstance(shortcuts['shortcuts'], dict):
         # Check the type of the value
         if not isinstance(value, (str, int, dict)):
             pass
-
 
 # Define the path of the Launchers
 epicshortcutdirectory = '$epicshortcutdirectory'
@@ -3088,7 +2808,6 @@ chromedirectory = '$chromedirectory'
 websites_str = '$custom_websites_str'
 custom_websites = websites_str.split(', ')
 
-
 app_ids = []
 
 
@@ -3098,8 +2817,8 @@ def get_steam_shortcut_id(exe, appname):
     return id_int
 
 
-
 app_id_to_name = {}
+
 
 def create_new_entry(shortcutdirectory, appname, launchoptions, startingdir):
     if shortcutdirectory != '' and launchoptions != '':
@@ -3221,23 +2940,15 @@ for custom_website in custom_websites:
         # Call the create_new_entry function for this website
         create_new_entry('$chromedirectory', game_name, chromelaunch_options, '$chrome_startdir')
 
-
-
 print(f'app_id_to_name: {app_id_to_name}')
 
 # Save the updated shortcuts dictionary to the shortcuts.vdf file
 with open('$shortcuts_vdf_path', 'wb') as f:
     vdf.binary_dump(shortcuts, f)
 
-
-
-
-
 # Writes to the config.vdf File
 
-
 excluded_appids = []
-
 
 # Update the config.vdf file
 with open('$config_vdf_path', 'r') as f:
@@ -3262,12 +2973,6 @@ for app_id in app_ids:
 # Save the updated config dictionary to the config.vdf file
 with open('$config_vdf_path', 'w') as f:
     vdf.dump(config, f)
-
-
-
-
-
-
 
 # Load the configset_controller_neptune.vdf file
 with open('$controller_config_path', 'r') as f:
@@ -3350,24 +3055,9 @@ config['controller_config']['amazon luna'] = {
     'template': 'controller_neptune_gamepad+mouse.vdf'
 }
 
-
-
-
-
-
-
-
-
-
-
-
-
 # Save the updated config dictionary to the configset_controller_neptune.vdf file
 with open('$controller_config_path', 'w') as f:
     vdf.dump(config, f)
-
-
-
 
 # Define the path to the compatdata directory
 compatdata_dir = '$HOME/.local/share/Steam/steamapps/compatdata'
@@ -3436,11 +3126,5 @@ if os.path.exists(os.path.join(compatdata_dir, 'NonSteamLaunchers')):
     # Create a symbolic link to the renamed NonSteamLaunchers folder
     os.symlink(new_path, symlink_path)"
 
-
-
-
-
-
 # Delete NonSteamLaunchersInstallation subfolder in Downloads folder
 rm -rf ~/Downloads/NonSteamLaunchersInstallation
-

--- a/NonSteamLaunchers.sh
+++ b/NonSteamLaunchers.sh
@@ -3,7 +3,7 @@
 # shellcheck disable=SC2155
 
 # Create a log file in the same directory as the desktop file/.sh file
-exec >> $HOME/Downloads/NonSteamLaunchers-install.log 2>&1
+exec >> ${logged_in_home}/Downloads/NonSteamLaunchers-install.log 2>&1
 
 # TODO: this is silly -- if the script is being executed, doesn't need to mark itself as executable
 # * better to set permissions at a repo-level
@@ -40,10 +40,20 @@ if [ ${#args[@]} -eq 0 ]; then
     check_for_updates
 fi
 
+# environment variables
+# $USER
+logged_in_user=$(logname)
+
+# $UID
+# logged_in_uid=$(id -u "${logged_in_user}")
+
+# $HOME
+logged_in_home=$(eval echo "~${logged_in_user}")
+
 # Check if the NonSteamLaunchersInstallation subfolder exists in the Downloads folder
-if [ -d "$HOME/Downloads/NonSteamLaunchersInstallation" ]; then
+if [ -d "${logged_in_home}/Downloads/NonSteamLaunchersInstallation" ]; then
     # Delete the NonSteamLaunchersInstallation subfolder
-    rm -rf "$HOME/Downloads/NonSteamLaunchersInstallation"
+    rm -rf "${logged_in_home}/Downloads/NonSteamLaunchersInstallation"
     echo "Deleted NonSteamLaunchersInstallation subfolder"
 else
     echo "NonSteamLaunchersInstallation subfolder does not exist"
@@ -53,38 +63,38 @@ fi
 
 # TODO: parameterize hard-coded client versions (cf. 'app-25.6.2')
 # Set the paths to the launcher executables
-epic_games_launcher_path1="$HOME/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/pfx/drive_c/Program Files (x86)/Epic Games/Launcher/Portal/Binaries/Win32/EpicGamesLauncher.exe"
-epic_games_launcher_path2="$HOME/.local/share/Steam/steamapps/compatdata/EpicGamesLauncher/pfx/drive_c/Program Files (x86)/Epic Games/Launcher/Portal/Binaries/Win32/EpicGamesLauncher.exe"
-gog_galaxy_path1="$HOME/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/pfx/drive_c/Program Files (x86)/GOG Galaxy/GalaxyClient.exe"
-gog_galaxy_path2="$HOME/.local/share/Steam/steamapps/compatdata/GogGalaxyLauncher/pfx/drive_c/Program Files (x86)/GOG Galaxy/GalaxyClient.exe"
-origin_path1="$HOME/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/pfx/drive_c/Program Files (x86)/Origin/Origin.exe"
-origin_path2="$HOME/.local/share/Steam/steamapps/compatdata/OriginLauncher/pfx/drive_c/Program Files (x86)/Origin/Origin.exe"
-uplay_path1="$HOME/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/pfx/drive_c/Program Files (x86)/Ubisoft/Ubisoft Game Launcher/upc.exe"
-uplay_path2="$HOME/.local/share/Steam/steamapps/compatdata/UplayLauncher/pfx/drive_c/Program Files (x86)/Ubisoft/Ubisoft Game Launcher/upc.exe"
-battlenet_path1="$HOME/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/pfx/drive_c/Program Files (x86)/Battle.net/Battle.net Launcher.exe"
-battlenet_path2="$HOME/.local/share/Steam/steamapps/compatdata/Battle.netLauncher/pfx/drive_c/Program Files (x86)/Battle.net/Battle.net Launcher.exe"
-eaapp_path1="$HOME/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/pfx/drive_c/Program Files/Electronic Arts/EA Desktop/EA Desktop/EADesktop.exe"
-eaapp_path2="$HOME/.local/share/Steam/steamapps/compatdata/TheEAappLauncher/pfx/drive_c/Program Files/Electronic Arts/EA Desktop/EA Desktop/EADesktop.exe"
-amazongames_path1="$HOME/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/pfx/drive_c/users/steamuser/AppData/Local/Amazon Games/App/Amazon Games.exe"
-amazongames_path2="$HOME/.local/share/Steam/steamapps/compatdata/AmazonGamesLauncher/pfx/drive_c/users/steamuser/AppData/Local/Amazon Games/App/Amazon Games.exe"
-itchio_path1="$HOME/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/pfx/drive_c/users/steamuser/AppData/Local/itch/app-25.6.2/itch.exe"
-itchio_path2="$HOME/.local/share/Steam/steamapps/compatdata/itchioLauncher/pfx/drive_c/users/steamuser/AppData/Local/itch/app-25.6.2/itch.exe"
-legacygames_path1="$HOME/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/pfx/drive_c/Program Files/Legacy Games/Legacy Games Launcher/Legacy Games Launcher.exe"
-legacygames_path2="$HOME/.local/share/Steam/steamapps/compatdata/LegacyGamesLauncher/pfx/drive_c/Program Files/Legacy Games/Legacy Games Launcher/Legacy Games Launcher.exe"
-humblegames_path1="$HOME/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/pfx/drive_c/Program Files/Humble App/Humble App.exe"
-humblegames_path2="$HOME/.local/share/Steam/steamapps/compatdata/HumbleGamesLauncher/pfx/drive_c/Program Files/Humble App/Humble App.exe"
-indiegala_path1="$HOME/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/pfx/drive_c/Program Files/IGClient/IGClient.exe"
-indiegala_path2="$HOME/.local/share/Steam/steamapps/compatdata/IndieGalaLauncher/pfx/drive_c/Program Files/IGClient/IGClient.exe"
-rockstar_path1="$HOME/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/pfx/drive_c/Program Files/Rockstar Games/Launcher/Launcher.exe"
-rockstar_path2="$HOME/.local/share/Steam/steamapps/compatdata/RockstarGamesLauncher/pfx/drive_c/Program Files/Rockstar Games/Launcher/Launcher.exe"
-glyph_path1="$HOME/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/pfx/drive_c/Program Files (x86)/Glyph/GlyphClient.exe"
-glyph_path2="$HOME/.local/share/Steam/steamapps/compatdata/GlyphLauncher/pfx/drive_c/Program Files (x86)/Glyph/GlyphClient.exe"
-minecraft_path1="$HOME/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/pfx/drive_c/Program Files (x86)/Minecraft Launcher/MinecraftLauncher.exe"
-minecraft_path2="$HOME/.local/share/Steam/steamapps/compatdata/MinecraftLauncher/pfx/drive_c/Program Files (x86)/Minecraft Launcher/MinecraftLauncher.exe"
-psplus_path1="$HOME/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/pfx/drive_c/Program Files (x86)/PlayStationPlus/pspluslauncher.exe"
-psplus_path2="$HOME/.local/share/Steam/steamapps/compatdata/PlaystationPlusLauncher/pfx/drive_c/Program Files (x86)/PlayStationPlus/pspluslauncher.exe"
-dmm_path1="$HOME/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/pfx/drive_c/Program Files/DMMGamePlayer/DMMGamePlayer.exe"
-dmm_path2="$HOME/.local/share/Steam/steamapps/compatdata/DMMGameLauncher/pfx/drive_c/Program Files/DMMGamePlayer/DMMGamePlayer.exe"
+epic_games_launcher_path1="${logged_in_home}/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/pfx/drive_c/Program Files (x86)/Epic Games/Launcher/Portal/Binaries/Win32/EpicGamesLauncher.exe"
+epic_games_launcher_path2="${logged_in_home}/.local/share/Steam/steamapps/compatdata/EpicGamesLauncher/pfx/drive_c/Program Files (x86)/Epic Games/Launcher/Portal/Binaries/Win32/EpicGamesLauncher.exe"
+gog_galaxy_path1="${logged_in_home}/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/pfx/drive_c/Program Files (x86)/GOG Galaxy/GalaxyClient.exe"
+gog_galaxy_path2="${logged_in_home}/.local/share/Steam/steamapps/compatdata/GogGalaxyLauncher/pfx/drive_c/Program Files (x86)/GOG Galaxy/GalaxyClient.exe"
+origin_path1="${logged_in_home}/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/pfx/drive_c/Program Files (x86)/Origin/Origin.exe"
+origin_path2="${logged_in_home}/.local/share/Steam/steamapps/compatdata/OriginLauncher/pfx/drive_c/Program Files (x86)/Origin/Origin.exe"
+uplay_path1="${logged_in_home}/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/pfx/drive_c/Program Files (x86)/Ubisoft/Ubisoft Game Launcher/upc.exe"
+uplay_path2="${logged_in_home}/.local/share/Steam/steamapps/compatdata/UplayLauncher/pfx/drive_c/Program Files (x86)/Ubisoft/Ubisoft Game Launcher/upc.exe"
+battlenet_path1="${logged_in_home}/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/pfx/drive_c/Program Files (x86)/Battle.net/Battle.net Launcher.exe"
+battlenet_path2="${logged_in_home}/.local/share/Steam/steamapps/compatdata/Battle.netLauncher/pfx/drive_c/Program Files (x86)/Battle.net/Battle.net Launcher.exe"
+eaapp_path1="${logged_in_home}/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/pfx/drive_c/Program Files/Electronic Arts/EA Desktop/EA Desktop/EADesktop.exe"
+eaapp_path2="${logged_in_home}/.local/share/Steam/steamapps/compatdata/TheEAappLauncher/pfx/drive_c/Program Files/Electronic Arts/EA Desktop/EA Desktop/EADesktop.exe"
+amazongames_path1="${logged_in_home}/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/pfx/drive_c/users/steamuser/AppData/Local/Amazon Games/App/Amazon Games.exe"
+amazongames_path2="${logged_in_home}/.local/share/Steam/steamapps/compatdata/AmazonGamesLauncher/pfx/drive_c/users/steamuser/AppData/Local/Amazon Games/App/Amazon Games.exe"
+itchio_path1="${logged_in_home}/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/pfx/drive_c/users/steamuser/AppData/Local/itch/app-25.6.2/itch.exe"
+itchio_path2="${logged_in_home}/.local/share/Steam/steamapps/compatdata/itchioLauncher/pfx/drive_c/users/steamuser/AppData/Local/itch/app-25.6.2/itch.exe"
+legacygames_path1="${logged_in_home}/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/pfx/drive_c/Program Files/Legacy Games/Legacy Games Launcher/Legacy Games Launcher.exe"
+legacygames_path2="${logged_in_home}/.local/share/Steam/steamapps/compatdata/LegacyGamesLauncher/pfx/drive_c/Program Files/Legacy Games/Legacy Games Launcher/Legacy Games Launcher.exe"
+humblegames_path1="${logged_in_home}/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/pfx/drive_c/Program Files/Humble App/Humble App.exe"
+humblegames_path2="${logged_in_home}/.local/share/Steam/steamapps/compatdata/HumbleGamesLauncher/pfx/drive_c/Program Files/Humble App/Humble App.exe"
+indiegala_path1="${logged_in_home}/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/pfx/drive_c/Program Files/IGClient/IGClient.exe"
+indiegala_path2="${logged_in_home}/.local/share/Steam/steamapps/compatdata/IndieGalaLauncher/pfx/drive_c/Program Files/IGClient/IGClient.exe"
+rockstar_path1="${logged_in_home}/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/pfx/drive_c/Program Files/Rockstar Games/Launcher/Launcher.exe"
+rockstar_path2="${logged_in_home}/.local/share/Steam/steamapps/compatdata/RockstarGamesLauncher/pfx/drive_c/Program Files/Rockstar Games/Launcher/Launcher.exe"
+glyph_path1="${logged_in_home}/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/pfx/drive_c/Program Files (x86)/Glyph/GlyphClient.exe"
+glyph_path2="${logged_in_home}/.local/share/Steam/steamapps/compatdata/GlyphLauncher/pfx/drive_c/Program Files (x86)/Glyph/GlyphClient.exe"
+minecraft_path1="${logged_in_home}/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/pfx/drive_c/Program Files (x86)/Minecraft Launcher/MinecraftLauncher.exe"
+minecraft_path2="${logged_in_home}/.local/share/Steam/steamapps/compatdata/MinecraftLauncher/pfx/drive_c/Program Files (x86)/Minecraft Launcher/MinecraftLauncher.exe"
+psplus_path1="${logged_in_home}/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/pfx/drive_c/Program Files (x86)/PlayStationPlus/pspluslauncher.exe"
+psplus_path2="${logged_in_home}/.local/share/Steam/steamapps/compatdata/PlaystationPlusLauncher/pfx/drive_c/Program Files (x86)/PlayStationPlus/pspluslauncher.exe"
+dmm_path1="${logged_in_home}/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/pfx/drive_c/Program Files/DMMGamePlayer/DMMGamePlayer.exe"
+dmm_path2="${logged_in_home}/.local/share/Steam/steamapps/compatdata/DMMGameLauncher/pfx/drive_c/Program Files/DMMGamePlayer/DMMGamePlayer.exe"
 
 # Chrome File Path
 # chrome_installpath="/app/bin/chrome"
@@ -335,7 +345,7 @@ fi }
 # Verify launchers are installed
 function CheckInstallationDirectory {
     # Check if NonSteamLaunchers is installed
-    if [[ -d "$HOME/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers" ]]; then
+    if [[ -d "${logged_in_home}/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers" ]]; then
         # NonSteamLaunchers is installed
         nonsteamlauncher_move_value="TRUE"
     else
@@ -344,7 +354,7 @@ function CheckInstallationDirectory {
     fi
 
     # Check if EpicGamesLauncher is installed
-    if [[ -d "$HOME/.local/share/Steam/steamapps/compatdata/EpicGamesLauncher" ]]; then
+    if [[ -d "${logged_in_home}/.local/share/Steam/steamapps/compatdata/EpicGamesLauncher" ]]; then
         # EpicGamesLauncher is installed
         epicgameslauncher_move_value="TRUE"
     else
@@ -353,7 +363,7 @@ function CheckInstallationDirectory {
     fi
 
     # Check if GogGalaxyLauncher is installed
-    if [[ -d "$HOME/.local/share/Steam/steamapps/compatdata/GogGalaxyLauncher" ]]; then
+    if [[ -d "${logged_in_home}/.local/share/Steam/steamapps/compatdata/GogGalaxyLauncher" ]]; then
         # GogGalaxyLauncher is installed
         goggalaxylauncher_move_value="TRUE"
     else
@@ -362,7 +372,7 @@ function CheckInstallationDirectory {
     fi
 
     # Check if OriginLauncher is installed
-    if [[ -d "$HOME/.local/share/Steam/steamapps/compatdata/OriginLauncher" ]]; then
+    if [[ -d "${logged_in_home}/.local/share/Steam/steamapps/compatdata/OriginLauncher" ]]; then
         # OriginLauncher is installed
         originlauncher_move_value="TRUE"
     else
@@ -371,7 +381,7 @@ function CheckInstallationDirectory {
     fi
 
     # Check if UplayLauncher is installed
-    if [[ -d "$HOME/.local/share/Steam/steamapps/compatdata/UplayLauncher" ]]; then
+    if [[ -d "${logged_in_home}/.local/share/Steam/steamapps/compatdata/UplayLauncher" ]]; then
         # UplayLauncher is installed
         uplaylauncher_move_value="TRUE"
     else
@@ -380,7 +390,7 @@ function CheckInstallationDirectory {
     fi
 
     # Check if Battle.netLauncher is installed
-    if [[ -d "$HOME/.local/share/Steam/steamapps/compatdata/Battle.netLauncher" ]]; then
+    if [[ -d "${logged_in_home}/.local/share/Steam/steamapps/compatdata/Battle.netLauncher" ]]; then
         # Battle.netLauncher is installed
         battlenetlauncher_move_value="TRUE"
     else
@@ -389,7 +399,7 @@ function CheckInstallationDirectory {
     fi
 
     # Check if TheEAappLauncher is installed
-    if [[ -d "$HOME/.local/share/Steam/steamapps/compatdata/TheEAappLauncher" ]]; then
+    if [[ -d "${logged_in_home}/.local/share/Steam/steamapps/compatdata/TheEAappLauncher" ]]; then
         # TheEAappLauncher is installed
         eaapplauncher_move_value="TRUE"
     else
@@ -399,7 +409,7 @@ function CheckInstallationDirectory {
 
 
     # Check if AmazonGamesLauncher is installed
-    if [[ -d "$HOME/.local/share/Steam/steamapps/compatdata/AmazonGamesLauncher" ]]; then
+    if [[ -d "${logged_in_home}/.local/share/Steam/steamapps/compatdata/AmazonGamesLauncher" ]]; then
         # AmazonGamesLauncher is installed
         amazongameslauncher_move_value="TRUE"
     else
@@ -408,7 +418,7 @@ function CheckInstallationDirectory {
     fi
 
     # Check if itchioLauncher is installed
-    if [[ -d "$HOME/.local/share/Steam/steamapps/compatdata/itchioLauncher" ]]; then
+    if [[ -d "${logged_in_home}/.local/share/Steam/steamapps/compatdata/itchioLauncher" ]]; then
         # itchioLauncher is installed
         itchiolauncher_move_value="TRUE"
     else
@@ -417,7 +427,7 @@ function CheckInstallationDirectory {
     fi
 
     # Check if LegacyGamesLauncher is installed
-    if [[ -d "$HOME/.local/share/Steam/steamapps/compatdata/LegacyGamesLauncher" ]]; then
+    if [[ -d "${logged_in_home}/.local/share/Steam/steamapps/compatdata/LegacyGamesLauncher" ]]; then
         # LegacyGamesLauncher is installed
         legacygameslauncher_move_value="TRUE"
     else
@@ -426,7 +436,7 @@ function CheckInstallationDirectory {
     fi
 
     # Check if HumbleGamesLauncher is installed
-    if [[ -d "$HOME/.local/share/Steam/steamapps/compatdata/HumbleGamesLauncher" ]]; then
+    if [[ -d "${logged_in_home}/.local/share/Steam/steamapps/compatdata/HumbleGamesLauncher" ]]; then
         # HumbleGamesLauncher is installed
         humblegameslauncher_move_value="TRUE"
     else
@@ -435,7 +445,7 @@ function CheckInstallationDirectory {
     fi
 
     # Check if indiegala is installed
-    if [[ -d "$HOME/.local/share/Steam/steamapps/compatdata/IndieGalaLauncher" ]]; then
+    if [[ -d "${logged_in_home}/.local/share/Steam/steamapps/compatdata/IndieGalaLauncher" ]]; then
         # indiegalaLauncher is installed
         indiegalalauncher_move_value="TRUE"
     else
@@ -444,7 +454,7 @@ function CheckInstallationDirectory {
     fi
 
     # Check if rockstar is installed
-    if [[ -d "$HOME/.local/share/Steam/steamapps/compatdata/RockstarGamesLauncher" ]]; then
+    if [[ -d "${logged_in_home}/.local/share/Steam/steamapps/compatdata/RockstarGamesLauncher" ]]; then
         # rockstar games launcher is installed
         rockstargameslauncher_move_value="TRUE"
     else
@@ -453,7 +463,7 @@ function CheckInstallationDirectory {
     fi
 
     # Check if Glyph is installed
-    if [[ -d "$HOME/.local/share/Steam/steamapps/compatdata/GlyphLauncher" ]]; then
+    if [[ -d "${logged_in_home}/.local/share/Steam/steamapps/compatdata/GlyphLauncher" ]]; then
         # Glyph is installed
         glyphlauncher_move_value="TRUE"
     else
@@ -462,7 +472,7 @@ function CheckInstallationDirectory {
     fi
 
     # Check if Minecraft is installed
-    if [[ -d "$HOME/.local/share/Steam/steamapps/compatdata/MinecraftLauncher" ]]; then
+    if [[ -d "${logged_in_home}/.local/share/Steam/steamapps/compatdata/MinecraftLauncher" ]]; then
         # Minecraft is installed
         minecraftlauncher_move_value="TRUE"
     else
@@ -472,7 +482,7 @@ function CheckInstallationDirectory {
 
     # TODO: `pspluslauncher_move_value` is unused (SC2034)
     # Check if PlaystationPlus is installed
-    if [[ -d "$HOME/.local/share/Steam/steamapps/compatdata/PlaystationPlusLauncher" ]]; then
+    if [[ -d "${logged_in_home}/.local/share/Steam/steamapps/compatdata/PlaystationPlusLauncher" ]]; then
         # PlaystationPlus is installed
         pspluslauncher_move_value="TRUE"
     else
@@ -481,7 +491,7 @@ function CheckInstallationDirectory {
     fi
 
     # Check if DMM Player is installed
-    if [[ -d "$HOME/.local/share/Steam/steamapps/compatdata/DMMGameLauncher" ]]; then
+    if [[ -d "${logged_in_home}/.local/share/Steam/steamapps/compatdata/DMMGameLauncher" ]]; then
         # DMM Player is installed
         dmmlauncher_move_value="TRUE"
     else
@@ -538,6 +548,7 @@ else
     # Convert the selected_launchers array to a string by joining its elements with a `|` delimiter.
     selected_launchers_str=$(IFS="|"; echo "${selected_launchers[*]}")
 
+    # TODO: SC2199
     # Check if the `SEPARATE APP IDS - CHECK THIS TO SEPARATE YOUR PREFIX'S` option was included in the `selected_launchers` variable. If this option was included, set the value of the `separate_app_ids` variable to `true`, indicating that separate app IDs should be used. Otherwise, set it to `false`.
     if [[ "${selected_launchers[@]}" =~ "SEPARATE APP IDS - CHECK THIS TO SEPARATE YOUR PREFIX'S" ]]; then
         separate_app_ids=true
@@ -615,7 +626,7 @@ fi
 # Define the StartFreshFunction
 function StartFreshFunction {
     # Define the path to the compatdata directory
-    compatdata_dir="$HOME/.local/share/Steam/steamapps/compatdata"
+    compatdata_dir="${logged_in_home}/.local/share/Steam/steamapps/compatdata"
 
     # Define an array of original folder names
     folder_names=("EpicGamesLauncher" "GogGalaxyLauncher" "UplayLauncher" "OriginLauncher" "Battle.netLauncher" "TheEAappLauncher" "AmazonGamesLauncher" "itchioLauncher" "LegacyGamesLauncher" "HumbleGamesLauncher" "IndieGalaLauncher" "RockstarGamesLauncher" "GlyphLauncher" "MinecraftLauncher" "PlaystationPlusLauncher" "DMMGameLauncher")
@@ -750,11 +761,11 @@ if [[ $options == "Uninstall" ]]; then
         if [[ -f "$epic_games_launcher_path1" ]]; then
             # Epic Games Launcher was installed using the NonSteamLaunchers prefix
             # Add code here to run the Epic Games Launcher uninstaller
-            rm -rf "$HOME/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/pfx/drive_c/Program Files (x86)/Epic Games"
+            rm -rf "${logged_in_home}/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/pfx/drive_c/Program Files (x86)/Epic Games"
         elif [[ -f "$epic_games_launcher_path2" ]]; then
             # Epic Games Launcher was installed using a separate app ID
             # Add code here to delete the EpicGamesLauncher app ID folder
-            rm -rf "$HOME/.local/share/Steam/steamapps/compatdata/EpicGamesLauncher"
+            rm -rf "${logged_in_home}/.local/share/Steam/steamapps/compatdata/EpicGamesLauncher"
         fi
     fi
 
@@ -764,11 +775,11 @@ if [[ $options == "Uninstall" ]]; then
         if [[ -f "$gog_galaxy_path1" ]]; then
             # GOG Galaxy was installed using the NonSteamLaunchers prefix
             # Add code here to run the GOG Galaxy uninstaller
-            rm -rf "$HOME/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/pfx/drive_c/Program Files (x86)/GOG Galaxy"
+            rm -rf "${logged_in_home}/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/pfx/drive_c/Program Files (x86)/GOG Galaxy"
         elif [[ -f "$gog_galaxy_path2" ]]; then
             # GOG Galaxy was installed using a separate app ID
             # Add code here to delete the GogGalaxyLauncher app ID folder
-            rm -rf "$HOME/.local/share/Steam/steamapps/compatdata/GogGalaxyLauncher"
+            rm -rf "${logged_in_home}/.local/share/Steam/steamapps/compatdata/GogGalaxyLauncher"
         fi
     fi
 
@@ -778,11 +789,11 @@ if [[ $options == "Uninstall" ]]; then
         if [[ -f "$uplay_path1" ]]; then
             # Uplay was installed using the NonSteamLaunchers prefix
             # Add code here to run the Uplay uninstaller
-            rm -rf "$HOME/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/pfx/drive_c/Program Files (x86)/Ubisoft"
+            rm -rf "${logged_in_home}/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/pfx/drive_c/Program Files (x86)/Ubisoft"
         elif [[ -f "$uplay_path2" ]]; then
             # Uplay was installed using a separate app ID
             # Add code here to delete the UplayLauncher app ID folder
-            rm -rf "$HOME/.local/share/Steam/steamapps/compatdata/UplayLauncher"
+            rm -rf "${logged_in_home}/.local/share/Steam/steamapps/compatdata/UplayLauncher"
         fi
     fi
 
@@ -792,11 +803,11 @@ if [[ $options == "Uninstall" ]]; then
         if [[ -f "$origin_path1" ]]; then
             # Origin was installed using the NonSteamLaunchers prefix
             # Add code here to run the Origin uninstaller
-            rm -rf "$HOME/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/pfx/drive_c/Program Files (x86)/Origin"
+            rm -rf "${logged_in_home}/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/pfx/drive_c/Program Files (x86)/Origin"
         elif [[ -f "$origin_path2" ]]; then
             # Origin was installed using a separate app ID
             # Add code here to delete the OriginLauncher app ID folder
-            rm -rf "$HOME/.local/share/Steam/steamapps/compatdata/OriginLauncher"
+            rm -rf "${logged_in_home}/.local/share/Steam/steamapps/compatdata/OriginLauncher"
         fi
     fi
 
@@ -806,11 +817,11 @@ if [[ $options == "Uninstall" ]]; then
         if [[ -f "$battlenet_path1" ]]; then
             # Battle.net was installed using the NonSteamLaunchers prefix
             # Add code here to run the Battle.net uninstaller
-            rm -rf "$HOME/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/pfx/drive_c/Program Files (x86)/Battle.net"
+            rm -rf "${logged_in_home}/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/pfx/drive_c/Program Files (x86)/Battle.net"
         elif [[ -f "$battlenet_path2" ]]; then
             # Battle.net was installed using a separate app ID
             # Add code here to delete the Battle.netLauncher app ID folder
-            rm -rf "$HOME/.local/share/Steam/steamapps/compatdata/Battle.netLauncher"
+            rm -rf "${logged_in_home}/.local/share/Steam/steamapps/compatdata/Battle.netLauncher"
         fi
     fi
 
@@ -820,11 +831,11 @@ if [[ $options == "Uninstall" ]]; then
         if [[ -f "$eaapp_path1" ]]; then
             # EA App was installed using the NonSteamLaunchers prefix
             # Add code here to run the EA App uninstaller
-            rm -rf "$HOME/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/pfx/drive_c/Program Files/Electronic Arts"
+            rm -rf "${logged_in_home}/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/pfx/drive_c/Program Files/Electronic Arts"
         elif [[ -f "$eaapp_path2" ]]; then
             # EA App was installed using a separate app ID
             # Add code here to delete the EALauncher app ID folder
-            rm -rf "$HOME/.local/share/Steam/steamapps/compatdata/TheEAappLauncher"
+            rm -rf "${logged_in_home}/.local/share/Steam/steamapps/compatdata/TheEAappLauncher"
         fi
     fi
 
@@ -834,11 +845,11 @@ if [[ $options == "Uninstall" ]]; then
         if [[ -f "$amazongames_path1" ]]; then
             # Amazon Games was installed using the NonSteamLaunchers prefix
             # Add code here to run the Amazon Games uninstaller
-            rm -rf "$HOME/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/pfx/drive_c/users/steamuser/AppData/Local/Amazon Games"
+            rm -rf "${logged_in_home}/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/pfx/drive_c/users/steamuser/AppData/Local/Amazon Games"
         elif [[ -f "$amazongames_path2" ]]; then
             # Amazon Games was installed using a separate app ID
             # Add code here to delete the AmazonGamesLauncher app ID folder
-            rm -rf "$HOME/.local/share/Steam/steamapps/compatdata/AmazonGamesLauncher"
+            rm -rf "${logged_in_home}/.local/share/Steam/steamapps/compatdata/AmazonGamesLauncher"
         fi
     fi
 
@@ -848,11 +859,11 @@ if [[ $options == "Uninstall" ]]; then
         if [[ -f "$legacygames_path1" ]]; then
             # Legacy Games was installed using the NonSteamLaunchers prefix
             # Add code here to run the Legacy Games uninstaller
-            rm -rf "$HOME/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/pfx/drive_c/Program Files/Legacy Games"
+            rm -rf "${logged_in_home}/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/pfx/drive_c/Program Files/Legacy Games"
         elif [[ -f "$legacygames_path2" ]]; then
             # Legacy Games was installed using a separate app ID
             # Add code here to delete the LegacyGamesLauncher app ID folder
-            rm -rf "$HOME/.local/share/Steam/steamapps/compatdata/LegacyGamesLauncher"
+            rm -rf "${logged_in_home}/.local/share/Steam/steamapps/compatdata/LegacyGamesLauncher"
         fi
     fi
 
@@ -862,11 +873,11 @@ if [[ $options == "Uninstall" ]]; then
         if [[ -f "$itchio_path1" ]]; then
             # Itch.io was installed using the NonSteamLaunchers prefix
             # Add code here to run the Itch.io uninstaller
-            rm -rf "$HOME/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/pfx/drive_c/users/steamuser/AppData/Local/itch"
+            rm -rf "${logged_in_home}/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/pfx/drive_c/users/steamuser/AppData/Local/itch"
         elif [[ -f "$itchio_path2" ]]; then
             # Itch.io was installed using a separate app ID
             # Add code here to delete the Itch.ioLauncher app ID folder
-            rm -rf "$HOME/.local/share/Steam/steamapps/compatdata/itchioLauncher"
+            rm -rf "${logged_in_home}/.local/share/Steam/steamapps/compatdata/itchioLauncher"
         fi
     fi
 
@@ -876,11 +887,11 @@ if [[ $options == "Uninstall" ]]; then
         if [[ -f "$humblegames_path1" ]]; then
             # Humble Bundle was installed using the NonSteamLaunchers prefix
             # Add code here to run the Humble Bundle uninstaller
-            rm -rf "$HOME/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/pfx/drive_c/Program Files/Humble App"
+            rm -rf "${logged_in_home}/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/pfx/drive_c/Program Files/Humble App"
         elif [[ -f "$humblegames_path2" ]]; then
             # Humble Bundle was installed using a separate app ID
             # Add code here to delete the HumbleBundleLauncher app ID folder
-            rm -rf "$HOME/.local/share/Steam/steamapps/compatdata/HumbleGamesLauncher"
+            rm -rf "${logged_in_home}/.local/share/Steam/steamapps/compatdata/HumbleGamesLauncher"
         fi
     fi
 
@@ -890,11 +901,11 @@ if [[ $options == "Uninstall" ]]; then
         if [[ -f "$indiegala_path1" ]]; then
             # IndieGala was installed using the NonSteamLaunchers prefix
             # Add code here to run the IndieGala uninstaller
-            rm -rf "$HOME/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/pfx/drive_c/Program Files/IGClient"
+            rm -rf "${logged_in_home}/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/pfx/drive_c/Program Files/IGClient"
         elif [[ -f "$indiegala_path2" ]]; then
             # IndieGala was installed using a separate app ID
             # Add code here to delete the IndieGalaLauncher app ID folder
-            rm -rf "$HOME/.local/share/Steam/steamapps/compatdata/IndieGalaLauncher"
+            rm -rf "${logged_in_home}/.local/share/Steam/steamapps/compatdata/IndieGalaLauncher"
         fi
     fi
 
@@ -904,11 +915,11 @@ if [[ $options == "Uninstall" ]]; then
         if [[ -f "$rockstar_path1" ]]; then
             # Rockstar Games was installed using the NonSteamLaunchers prefix
             # Add code here to run the Rockstar Games uninstaller
-            rm -rf "$HOME/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/pfx/drive_c/Program Files/Rockstar Games"
+            rm -rf "${logged_in_home}/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/pfx/drive_c/Program Files/Rockstar Games"
         elif [[ -f "$rockstar_path2" ]]; then
             # Rockstar Games was installed using a separate app ID
             # Add code here to delete the RockstarGamesLauncher app ID folder
-            rm -rf "$HOME/.local/share/Steam/steamapps/compatdata/RockstarGamesLauncher"
+            rm -rf "${logged_in_home}/.local/share/Steam/steamapps/compatdata/RockstarGamesLauncher"
         fi
     fi
 
@@ -918,11 +929,11 @@ if [[ $options == "Uninstall" ]]; then
         if [[ -f "$glyph_path1" ]]; then
             # Glyph was installed using NonSteamLaunchers prefix
             # Add code here to run the Glyph uninstaller
-            rm -rf "$HOME/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/pfx/drive_c/Program Files (x86)/Glyph"
+            rm -rf "${logged_in_home}/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/pfx/drive_c/Program Files (x86)/Glyph"
         elif [[ -f "$glyph_path2" ]]; then
             # Glyph was installed using a separate app ID
             # Add code here to delete the GlyphLauncher app ID folder
-            rm -rf "$HOME/.local/share/Steam/steamapps/compatdata/GlyphLauncher"
+            rm -rf "${logged_in_home}/.local/share/Steam/steamapps/compatdata/GlyphLauncher"
         fi
     fi
 
@@ -932,11 +943,11 @@ if [[ $options == "Uninstall" ]]; then
         if [[ -f "$minecraft_path1" ]]; then
             # Minecraft was installed using NonSteamLaunchers prefix
             # Add code here to run the Minecraft uninstaller
-            rm -rf "$HOME/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/pfx/drive_c/Program Files (x86)/Minecraft Launcher"
+            rm -rf "${logged_in_home}/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/pfx/drive_c/Program Files (x86)/Minecraft Launcher"
         elif [[ -f "$minecraft_path2" ]]; then
             # Minecraft was installed using a separate app ID
             # Add code here to delete the MinecraftLauncher app ID folder
-            rm -rf "$HOME/.local/share/Steam/steamapps/compatdata/MinecraftLauncher"
+            rm -rf "${logged_in_home}/.local/share/Steam/steamapps/compatdata/MinecraftLauncher"
         fi
     fi
 
@@ -946,11 +957,11 @@ if [[ $options == "Uninstall" ]]; then
         if [[ -f "$psplus_path1" ]]; then
             # Playstation was installed using NonSteamLaunchers prefix
             # Add code here to run the Playstation uninstaller
-            rm -rf "$HOME/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/pfx/drive_c/Program Files (x86)/PlayStationPlus"
+            rm -rf "${logged_in_home}/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/pfx/drive_c/Program Files (x86)/PlayStationPlus"
         elif [[ -f "$psplus_path2" ]]; then
             # Playstation was installed using a separate app ID
             # Add code here to delete the PlaystationPlusLauncher app ID folder
-            rm -rf "$HOME/.local/share/Steam/steamapps/compatdata/PlaystationPlusLauncher"
+            rm -rf "${logged_in_home}/.local/share/Steam/steamapps/compatdata/PlaystationPlusLauncher"
         fi
     fi
 
@@ -960,11 +971,11 @@ if [[ $options == "Uninstall" ]]; then
         if [[ -f "$dmm_path1" ]]; then
             # DMMGameLauncher was installed using NonSteamLaunchers prefix
             # Add code here to run the DMMGameLauncher uninstaller
-            rm -rf "$HOME/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/pfx/drive_c/Program Files (x86)/DMMGamePlayer"
+            rm -rf "${logged_in_home}/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/pfx/drive_c/Program Files (x86)/DMMGamePlayer"
         elif [[ -f "$dmm_path2" ]]; then
             # DMMGameLauncher was installed using a separate app ID
             # Add code here to delete the DMMGameLauncher app ID folder
-            rm -rf "$HOME/.local/share/Steam/steamapps/compatdata/DMMGameLauncher"
+            rm -rf "${logged_in_home}/.local/share/Steam/steamapps/compatdata/DMMGameLauncher"
         fi
     fi
     # Display a message to the user indicating that the operation was successful
@@ -995,9 +1006,9 @@ if [[ $options == "Move to SD Card" ]]; then
     new_dir="/run/media/mmcblk0p1"
 
     # Check if NonSteamLaunchers is installed
-    if [[ -d "$HOME/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers" ]]; then
+    if [[ -d "${logged_in_home}/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers" ]]; then
         # NonSteamLaunchers is installed
-        original_dir="$HOME/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers"
+        original_dir="${logged_in_home}/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers"
     else
         # NonSteamLaunchers is not installed
         original_dir=""
@@ -1013,9 +1024,9 @@ if [[ $options == "Move to SD Card" ]]; then
     fi
 
     # Check if EpicGamesLauncher is installed
-    if [[ -d "$HOME/.local/share/Steam/steamapps/compatdata/EpicGamesLauncher" ]]; then
+    if [[ -d "${logged_in_home}/.local/share/Steam/steamapps/compatdata/EpicGamesLauncher" ]]; then
         # EpicGamesLauncher is installed
-        original_dir="$HOME/.local/share/Steam/steamapps/compatdata/EpicGamesLauncher"
+        original_dir="${logged_in_home}/.local/share/Steam/steamapps/compatdata/EpicGamesLauncher"
     else
         # EpicGamesLauncher is not installed
         original_dir=""
@@ -1031,9 +1042,9 @@ if [[ $options == "Move to SD Card" ]]; then
     fi
 
     # Check if GogGalaxyLauncher is installed
-    if [[ -d "$HOME/.local/share/Steam/steamapps/compatdata/GogGalaxyLauncher" ]]; then
+    if [[ -d "${logged_in_home}/.local/share/Steam/steamapps/compatdata/GogGalaxyLauncher" ]]; then
         # GogGalaxyLauncher is installed
-        original_dir="$HOME/.local/share/Steam/steamapps/compatdata/GogGalaxyLauncher"
+        original_dir="${logged_in_home}/.local/share/Steam/steamapps/compatdata/GogGalaxyLauncher"
     else
         # GogGalaxyLauncher is not installed
         original_dir=""
@@ -1049,9 +1060,9 @@ if [[ $options == "Move to SD Card" ]]; then
     fi
 
     # Check if OriginLauncher is installed
-    if [[ -d "$HOME/.local/share/Steam/steamapps/compatdata/OriginLauncher" ]]; then
+    if [[ -d "${logged_in_home}/.local/share/Steam/steamapps/compatdata/OriginLauncher" ]]; then
         # OriginLauncher is installed
-        original_dir="$HOME/.local/share/Steam/steamapps/compatdata/OriginLauncher"
+        original_dir="${logged_in_home}/.local/share/Steam/steamapps/compatdata/OriginLauncher"
     else
         # OriginLauncher is not installed
         original_dir=""
@@ -1067,9 +1078,9 @@ if [[ $options == "Move to SD Card" ]]; then
     fi
 
     # Check if UplayLauncher is installed
-    if [[ -d "$HOME/.local/share/Steam/steamapps/compatdata/UplayLauncher" ]]; then
+    if [[ -d "${logged_in_home}/.local/share/Steam/steamapps/compatdata/UplayLauncher" ]]; then
         # UplayLauncher is installed
-        original_dir="$HOME/.local/share/Steam/steamapps/compatdata/UplayLauncher"
+        original_dir="${logged_in_home}/.local/share/Steam/steamapps/compatdata/UplayLauncher"
     else
         # UplayLauncher is not installed
         original_dir=""
@@ -1085,9 +1096,9 @@ if [[ $options == "Move to SD Card" ]]; then
     fi
 
     # Check if Battle.netLauncher is installed
-    if [[ -d "$HOME/.local/share/Steam/steamapps/compatdata/Battle.netLauncher" ]]; then
+    if [[ -d "${logged_in_home}/.local/share/Steam/steamapps/compatdata/Battle.netLauncher" ]]; then
         # Battle.netLauncher is installed
-        original_dir="$HOME/.local/share/Steam/steamapps/compatdata/Battle.netLauncher"
+        original_dir="${logged_in_home}/.local/share/Steam/steamapps/compatdata/Battle.netLauncher"
     else
         # Battle.netLauncher is not installed
         original_dir=""
@@ -1103,9 +1114,9 @@ if [[ $options == "Move to SD Card" ]]; then
     fi
 
     # Check if TheEAappLauncher is installed
-    if [[ -d "$HOME/.local/share/Steam/steamapps/compatdata/TheEAappLauncher" ]]; then
+    if [[ -d "${logged_in_home}/.local/share/Steam/steamapps/compatdata/TheEAappLauncher" ]]; then
         # TheEAappLauncher is installed
-        original_dir="$HOME/.local/share/Steam/steamapps/compatdata/TheEAappLauncher"
+        original_dir="${logged_in_home}/.local/share/Steam/steamapps/compatdata/TheEAappLauncher"
     else
         # TheEAappLauncher is not installed
         original_dir=""
@@ -1121,9 +1132,9 @@ if [[ $options == "Move to SD Card" ]]; then
     fi
 
     # Check if AmazonGamesLauncher is installed
-    if [[ -d "$HOME/.local/share/Steam/steamapps/compatdata/AmazonGamesLauncher" ]]; then
+    if [[ -d "${logged_in_home}/.local/share/Steam/steamapps/compatdata/AmazonGamesLauncher" ]]; then
         # AmazonGamesLauncher is installed
-        original_dir="$HOME/.local/share/Steam/steamapps/compatdata/AmazonGamesLauncher"
+        original_dir="${logged_in_home}/.local/share/Steam/steamapps/compatdata/AmazonGamesLauncher"
     else
         # AmazonGamesLauncher is not installed
         original_dir=""
@@ -1139,9 +1150,9 @@ if [[ $options == "Move to SD Card" ]]; then
     fi
 
     # Check if itchioLauncher is installed
-    if [[ -d "$HOME/.local/share/Steam/steamapps/compatdata/itchioLauncher" ]]; then
+    if [[ -d "${logged_in_home}/.local/share/Steam/steamapps/compatdata/itchioLauncher" ]]; then
         # itchioLauncher is installed
-        original_dir="$HOME/.local/share/Steam/steamapps/compatdata/itchioLauncher"
+        original_dir="${logged_in_home}/.local/share/Steam/steamapps/compatdata/itchioLauncher"
     else
         # itchioLauncher is not installed
         original_dir=""
@@ -1157,9 +1168,9 @@ if [[ $options == "Move to SD Card" ]]; then
     fi
 
     # Check if LegacyGamesLauncher is installed
-    if [[ -d "$HOME/.local/share/Steam/steamapps/compatdata/LegacyGamesLauncher" ]]; then
+    if [[ -d "${logged_in_home}/.local/share/Steam/steamapps/compatdata/LegacyGamesLauncher" ]]; then
         # LegacyGamesLauncher is installed
-        original_dir="$HOME/.local/share/Steam/steamapps/compatdata/LegacyGamesLauncher"
+        original_dir="${logged_in_home}/.local/share/Steam/steamapps/compatdata/LegacyGamesLauncher"
     else
         # LegacyGamesLauncher is not installed
         original_dir=""
@@ -1175,9 +1186,9 @@ if [[ $options == "Move to SD Card" ]]; then
     fi
 
     # Check if HumbleGamesLauncher is installed
-    if [[ -d "$HOME/.local/share/Steam/steamapps/compatdata/HumbleGamesLauncher" ]]; then
+    if [[ -d "${logged_in_home}/.local/share/Steam/steamapps/compatdata/HumbleGamesLauncher" ]]; then
         # HumbleGamesLauncher is installed
-        original_dir="$HOME/.local/share/Steam/steamapps/compatdata/HumbleGamesLauncher"
+        original_dir="${logged_in_home}/.local/share/Steam/steamapps/compatdata/HumbleGamesLauncher"
     else
         # HumbleGamesLauncher is not installed
         original_dir=""
@@ -1193,9 +1204,9 @@ if [[ $options == "Move to SD Card" ]]; then
     fi
 
     # Check if IndieGalaLauncher is installed
-    if [[ -d "$HOME/.local/share/Steam/steamapps/compatdata/IndieGalaLauncher" ]]; then
+    if [[ -d "${logged_in_home}/.local/share/Steam/steamapps/compatdata/IndieGalaLauncher" ]]; then
         # IndieGalaLauncher is installed
-        original_dir="$HOME/.local/share/Steam/steamapps/compatdata/IndieGalaLauncher"
+        original_dir="${logged_in_home}/.local/share/Steam/steamapps/compatdata/IndieGalaLauncher"
     else
         # Indie Gala Launcher is not installed
         original_dir=""
@@ -1211,9 +1222,9 @@ if [[ $options == "Move to SD Card" ]]; then
     fi
 
     # Check if RockstarGamesLauncher is installed
-    if [[ -d "$HOME/.local/share/Steam/steamapps/compatdata/RockstarGamesLauncher" ]]; then
+    if [[ -d "${logged_in_home}/.local/share/Steam/steamapps/compatdata/RockstarGamesLauncher" ]]; then
         # RockstarGamesLauncher is installed
-        original_dir="$HOME/.local/share/Steam/steamapps/compatdata/RockstarGamesLauncher"
+        original_dir="${logged_in_home}/.local/share/Steam/steamapps/compatdata/RockstarGamesLauncher"
     else
         # Rockstar Games Launcher is not installed
         original_dir=""
@@ -1229,9 +1240,9 @@ if [[ $options == "Move to SD Card" ]]; then
     fi
 
     # Check if Glyph is installed
-    if [[ -d "$HOME/.local/share/Steam/steamapps/compatdata/GlyphLauncher" ]]; then
+    if [[ -d "${logged_in_home}/.local/share/Steam/steamapps/compatdata/GlyphLauncher" ]]; then
         # Glyph is installed
-        original_dir="$HOME/.local/share/Steam/steamapps/compatdata/GlyphLauncher"
+        original_dir="${logged_in_home}/.local/share/Steam/steamapps/compatdata/GlyphLauncher"
     else
         # Glyph is not installed
         original_dir=""
@@ -1247,9 +1258,9 @@ if [[ $options == "Move to SD Card" ]]; then
     fi
 
     # Check if Minecraft is installed
-    if [[ -d "$HOME/.local/share/Steam/steamapps/compatdata/MinecraftLauncher" ]]; then
+    if [[ -d "${logged_in_home}/.local/share/Steam/steamapps/compatdata/MinecraftLauncher" ]]; then
         # Minecraft is installed
-        original_dir="$HOME/.local/share/Steam/steamapps/compatdata/MinecraftLauncher"
+        original_dir="${logged_in_home}/.local/share/Steam/steamapps/compatdata/MinecraftLauncher"
     else
         # Minecraft is not installed
         original_dir=""
@@ -1292,14 +1303,14 @@ fi
 if [[ $options == "Find Games" ]]; then
     # The Find Games button was clicked
     # Check if the NonSteamLaunchersInstallation directory exists
-    if [[ ! -d "$HOME/Downloads/NonSteamLaunchersInstallation" ]]; then
+    if [[ ! -d "${logged_in_home}/Downloads/NonSteamLaunchersInstallation" ]]; then
         # The directory does not exist, so create it
-        mkdir -p "$HOME/Downloads/NonSteamLaunchersInstallation"
+        mkdir -p "${logged_in_home}/Downloads/NonSteamLaunchersInstallation"
     fi
 
     # Download the latest BoilR from GitHub (Linux version)
-    mkdir -p "$HOME/Downloads/NonSteamLaunchersInstallation"
-    cd "$HOME/Downloads/NonSteamLaunchersInstallation"
+    mkdir -p "${logged_in_home}/Downloads/NonSteamLaunchersInstallation"
+    cd "${logged_in_home}/Downloads/NonSteamLaunchersInstallation"
     wget https://github.com/PhilipK/BoilR/releases/download/v.1.9.1/linux_BoilR
 
     # Add execute permissions to the linux_BoilR file
@@ -1321,8 +1332,8 @@ echo "0"
 echo "# Detecting, Updating and Installing GE-Proton"
 
 # check to make sure compatabilitytools.d exists and makes it if it doesnt
-    if [ ! -d "$HOME/.steam/root/compatibilitytools.d" ]; then
-    mkdir -p "$HOME/.steam/root/compatibilitytools.d"
+    if [ ! -d "${logged_in_home}/.steam/root/compatibilitytools.d" ]; then
+    mkdir -p "${logged_in_home}/.steam/root/compatibilitytools.d"
 fi
 
 # Create NonSteamLaunchersInstallation subfolder in Downloads folder
@@ -1498,8 +1509,8 @@ if [ -n "$options" ]; then
     # User selected at least one launcher
 
     # Create app id folder in compatdata folder if it doesn't exist and if the user selected to use a single app ID folder
-    if [ "$use_separate_appids" = false ] && [ ! -d "$HOME/.local/share/Steam/steamapps/compatdata/$appid" ]; then
-        mkdir -p "$HOME/.local/share/Steam/steamapps/compatdata/$appid"
+    if [ "$use_separate_appids" = false ] && [ ! -d "${logged_in_home}/.local/share/Steam/steamapps/compatdata/$appid" ]; then
+        mkdir -p "${logged_in_home}/.local/share/Steam/steamapps/compatdata/$appid"
     fi
 fi
 
@@ -1507,13 +1518,13 @@ fi
 cd $proton_dir
 
 # Set the STEAM_RUNTIME environment variable
-export STEAM_RUNTIME="$HOME/.steam/root/ubuntu12_32/steam-runtime/run.sh"
+export STEAM_RUNTIME="${logged_in_home}/.steam/root/ubuntu12_32/steam-runtime/run.sh"
 
 # Set the STEAM_COMPAT_CLIENT_INSTALL_PATH environment variable
-export STEAM_COMPAT_CLIENT_INSTALL_PATH="$HOME/.local/share/Steam"
+export STEAM_COMPAT_CLIENT_INSTALL_PATH="${logged_in_home}/.local/share/Steam"
 
 # Set the STEAM_COMPAT_DATA_PATH environment variable for the first file
-export STEAM_COMPAT_DATA_PATH="$HOME/.local/share/Steam/steamapps/compatdata/${appid}"
+export STEAM_COMPAT_DATA_PATH="${logged_in_home}/.local/share/Steam/steamapps/compatdata/${appid}"
 
 wait
 echo "30"
@@ -1526,24 +1537,24 @@ if [[ $options == *"Epic Games"* ]]; then
 
     # Set the appid for the Epic Games Launcher
     if [ "$use_separate_appids" = true ]; then
-    appid=EpicGamesLauncher
+        appid=EpicGamesLauncher
     else
-    appid=NonSteamLaunchers
+        appid=NonSteamLaunchers
     fi
 
     # Create app id folder in compatdata folder if it doesn't exist
-    if [ ! -d "$HOME/.local/share/Steam/steamapps/compatdata/$appid" ]; then
-        mkdir -p "$HOME/.local/share/Steam/steamapps/compatdata/$appid"
+    if [ ! -d "${logged_in_home}/.local/share/Steam/steamapps/compatdata/$appid" ]; then
+        mkdir -p "${logged_in_home}/.local/share/Steam/steamapps/compatdata/$appid"
     fi
 
     # Change working directory to Proton's
     cd $proton_dir
 
     # Set the STEAM_COMPAT_CLIENT_INSTALL_PATH environment variable
-    export STEAM_COMPAT_CLIENT_INSTALL_PATH="$HOME/.local/share/Steam"
+    export STEAM_COMPAT_CLIENT_INSTALL_PATH="${logged_in_home}/.local/share/Steam"
 
     # Set the STEAM_COMPAT_DATA_PATH environment variable for Epic Games Launcher
-    export STEAM_COMPAT_DATA_PATH="$HOME/.local/share/Steam/steamapps/compatdata/${appid}"
+    export STEAM_COMPAT_DATA_PATH="${logged_in_home}/.local/share/Steam/steamapps/compatdata/${appid}"
 
     # Download MSI file
     if [ ! -f "$msi_file" ]; then
@@ -1575,18 +1586,18 @@ if [[ $options == *"GOG Galaxy"* ]]; then
     fi
 
     # Create app id folder in compatdata folder if it doesn't exist
-    if [ ! -d "$HOME/.local/share/Steam/steamapps/compatdata/$appid" ]; then
-        mkdir -p "$HOME/.local/share/Steam/steamapps/compatdata/$appid"
+    if [ ! -d "${logged_in_home}/.local/share/Steam/steamapps/compatdata/$appid" ]; then
+        mkdir -p "${logged_in_home}/.local/share/Steam/steamapps/compatdata/$appid"
     fi
 
     # Change working directory to Proton's
     cd "$proton_dir"
 
     # Set the STEAM_COMPAT_CLIENT_INSTALL_PATH environment variable
-    export STEAM_COMPAT_CLIENT_INSTALL_PATH="$HOME/.local/share/Steam"
+    export STEAM_COMPAT_CLIENT_INSTALL_PATH="${logged_in_home}/.local/share/Steam"
 
     # Set the STEAM_COMPAT_DATA_PATH environment variable for Epic Games Launcher
-    export STEAM_COMPAT_DATA_PATH="$HOME/.local/share/Steam/steamapps/compatdata/${appid}"
+    export STEAM_COMPAT_DATA_PATH="${logged_in_home}/.local/share/Steam/steamapps/compatdata/${appid}"
 
     # Download EXE file
     if [ ! -f "$exe_file" ]; then
@@ -1611,7 +1622,7 @@ if [[ $options == *"GOG Galaxy"* ]]; then
     done
 
     # Navigate to %LocalAppData%\Temp
-    cd "$HOME/.local/share/Steam/steamapps/compatdata/$appid/pfx/drive_c/users/steamuser/Temp"
+    cd "${logged_in_home}/.local/share/Steam/steamapps/compatdata/$appid/pfx/drive_c/users/steamuser/Temp"
 
     # Find the GalaxyInstaller_XXXXX folder and copy it to C:\Downloads
     galaxy_installer_folder=$(find . -maxdepth 1 -type d -name "GalaxyInstaller_*" | head -n1)
@@ -1648,18 +1659,18 @@ if [[ $options == *"Uplay"* ]]; then
     fi
 
     # Create app id folder in compatdata folder if it doesn't exist
-    if [ ! -d "$HOME/.local/share/Steam/steamapps/compatdata/$appid" ]; then
-        mkdir -p "$HOME/.local/share/Steam/steamapps/compatdata/$appid"
+    if [ ! -d "${logged_in_home}/.local/share/Steam/steamapps/compatdata/$appid" ]; then
+        mkdir -p "${logged_in_home}/.local/share/Steam/steamapps/compatdata/$appid"
     fi
 
     # Change working directory to Proton's
     cd $proton_dir
 
     # Set the STEAM_COMPAT_CLIENT_INSTALL_PATH environment variable
-    export STEAM_COMPAT_CLIENT_INSTALL_PATH="$HOME/.local/share/Steam"
+    export STEAM_COMPAT_CLIENT_INSTALL_PATH="${logged_in_home}/.local/share/Steam"
 
     # Set the STEAM_COMPAT_DATA_PATH environment variable for Epic Games Launcher
-    export STEAM_COMPAT_DATA_PATH="$HOME/.local/share/Steam/steamapps/compatdata/${appid}"
+    export STEAM_COMPAT_DATA_PATH="${logged_in_home}/.local/share/Steam/steamapps/compatdata/${appid}"
 
     # Download UBI file
     if [ ! -f "$ubi_file" ]; then
@@ -1690,18 +1701,18 @@ if [[ $options == *"Origin"* ]]; then
     fi
 
     # Create app id folder in compatdata folder if it doesn't exist
-    if [ ! -d "$HOME/.local/share/Steam/steamapps/compatdata/$appid" ]; then
-        mkdir -p "$HOME/.local/share/Steam/steamapps/compatdata/$appid"
+    if [ ! -d "${logged_in_home}/.local/share/Steam/steamapps/compatdata/$appid" ]; then
+        mkdir -p "${logged_in_home}/.local/share/Steam/steamapps/compatdata/$appid"
     fi
 
     # Change working directory to Proton's
     cd $proton_dir
 
     # Set the STEAM_COMPAT_CLIENT_INSTALL_PATH environment variable
-    export STEAM_COMPAT_CLIENT_INSTALL_PATH="$HOME/.local/share/Steam"
+    export STEAM_COMPAT_CLIENT_INSTALL_PATH="${logged_in_home}/.local/share/Steam"
 
     # Set the STEAM_COMPAT_DATA_PATH environment variable for Epic Games Launcher
-    export STEAM_COMPAT_DATA_PATH="$HOME/.local/share/Steam/steamapps/compatdata/${appid}"
+    export STEAM_COMPAT_DATA_PATH="${logged_in_home}/.local/share/Steam/steamapps/compatdata/${appid}"
 
     # Download ORIGIN file
     if [ ! -f "$origin_file" ]; then
@@ -1714,20 +1725,20 @@ if [[ $options == *"Origin"* ]]; then
     "$STEAM_RUNTIME" "$proton_dir/proton" run "$origin_file" /SILENT
 
     # Edit local.xml
-    sed -i 's|</Settings>|    <Setting value="true" key="MigrationDisabled" type="1"/>\n    <Setting key="UpdateURL" value="" type="10"/>\n    <Setting key="AutoPatchGlobal" value="false" type="1"/>\n    <Setting key="AutoUpdate" value="false" type="1"/>\n</Settings>|' "$HOME/.local/share/Steam/steamapps/compatdata/$appid/pfx/drive_c/ProgramData/Origin/local.xml"
+    sed -i 's|</Settings>|    <Setting value="true" key="MigrationDisabled" type="1"/>\n    <Setting key="UpdateURL" value="" type="10"/>\n    <Setting key="AutoPatchGlobal" value="false" type="1"/>\n    <Setting key="AutoUpdate" value="false" type="1"/>\n</Settings>|' "${logged_in_home}/.local/share/Steam/steamapps/compatdata/$appid/pfx/drive_c/ProgramData/Origin/local.xml"
 
     # Terminate any processes with the name Origin.exe
     pkill Origin.exe
 
     # Download version.dll file
-    if [ ! -f "$HOME/Downloads/NonSteamLaunchersInstallation/version.dll" ]; then
+    if [ ! -f "${logged_in_home}/Downloads/NonSteamLaunchersInstallation/version.dll" ]; then
         echo "Downloading version.dll file"
         wget https://github.com/p0358/Fuck_off_EA_App/releases/download/v2/version.dll -O ~/Downloads/NonSteamLaunchersInstallation/version.dll
     fi
 
     # Move version.dll file to desired location
     echo "Moving version.dll file to desired location"
-    mv ~/Downloads/NonSteamLaunchersInstallation/version.dll "$HOME/.local/share/Steam/steamapps/compatdata/$appid/pfx/drive_c/Program Files (x86)/Origin/"
+    mv ~/Downloads/NonSteamLaunchersInstallation/version.dll "${logged_in_home}/.local/share/Steam/steamapps/compatdata/$appid/pfx/drive_c/Program Files (x86)/Origin/"
 
     # Wait for the ORIGIN file to finish running
     wait
@@ -1750,18 +1761,18 @@ if [[ $options == *"Battle.net"* ]]; then
     fi
 
     # Create app id folder in compatdata folder if it doesn't exist
-    if [ ! -d "$HOME/.local/share/Steam/steamapps/compatdata/$appid" ]; then
-        mkdir -p "$HOME/.local/share/Steam/steamapps/compatdata/$appid"
+    if [ ! -d "${logged_in_home}/.local/share/Steam/steamapps/compatdata/$appid" ]; then
+        mkdir -p "${logged_in_home}/.local/share/Steam/steamapps/compatdata/$appid"
     fi
 
     # Change working directory to Proton's
     cd $proton_dir
 
     # Set the STEAM_COMPAT_CLIENT_INSTALL_PATH environment variable
-    export STEAM_COMPAT_CLIENT_INSTALL_PATH="$HOME/.local/share/Steam"
+    export STEAM_COMPAT_CLIENT_INSTALL_PATH="${logged_in_home}/.local/share/Steam"
 
     # Set the STEAM_COMPAT_DATA_PATH environment variable for Epic Games Launcher
-    export STEAM_COMPAT_DATA_PATH="$HOME/.local/share/Steam/steamapps/compatdata/${appid}"
+    export STEAM_COMPAT_DATA_PATH="${logged_in_home}/.local/share/Steam/steamapps/compatdata/${appid}"
 
     # Download BATTLE file
     if [ ! -f "$battle_file" ]; then
@@ -1792,18 +1803,18 @@ if [[ $options == *"Amazon Games"* ]]; then
     fi
 
     # Create app id folder in compatdata folder if it doesn't exist
-    if [ ! -d "$HOME/.local/share/Steam/steamapps/compatdata/$appid" ]; then
-        mkdir -p "$HOME/.local/share/Steam/steamapps/compatdata/$appid"
+    if [ ! -d "${logged_in_home}/.local/share/Steam/steamapps/compatdata/$appid" ]; then
+        mkdir -p "${logged_in_home}/.local/share/Steam/steamapps/compatdata/$appid"
     fi
 
     # Change working directory to Proton's
     cd $proton_dir
 
     # Set the STEAM_COMPAT_CLIENT_INSTALL_PATH environment variable
-    export STEAM_COMPAT_CLIENT_INSTALL_PATH="$HOME/.local/share/Steam"
+    export STEAM_COMPAT_CLIENT_INSTALL_PATH="${logged_in_home}/.local/share/Steam"
 
     # Set the STEAM_COMPAT_DATA_PATH environment variable for Amazon Games Launcher
-    export STEAM_COMPAT_DATA_PATH="$HOME/.local/share/Steam/steamapps/compatdata/${appid}"
+    export STEAM_COMPAT_DATA_PATH="${logged_in_home}/.local/share/Steam/steamapps/compatdata/${appid}"
 
     # Download Amazon file
     if [ ! -f "$amazon_file" ]; then
@@ -1845,18 +1856,18 @@ if [[ $options == *"EA App"* ]]; then
     fi
 
     # Create app id folder in compatdata folder if it doesn't exist
-    if [ ! -d "$HOME/.local/share/Steam/steamapps/compatdata/$appid" ]; then
-        mkdir -p "$HOME/.local/share/Steam/steamapps/compatdata/$appid"
+    if [ ! -d "${logged_in_home}/.local/share/Steam/steamapps/compatdata/$appid" ]; then
+        mkdir -p "${logged_in_home}/.local/share/Steam/steamapps/compatdata/$appid"
     fi
 
     # Change working directory to Proton's
     cd $proton_dir
 
     # Set the STEAM_COMPAT_CLIENT_INSTALL_PATH environment variable
-    export STEAM_COMPAT_CLIENT_INSTALL_PATH="$HOME/.local/share/Steam"
+    export STEAM_COMPAT_CLIENT_INSTALL_PATH="${logged_in_home}/.local/share/Steam"
 
     # Set the STEAM_COMPAT_DATA_PATH environment variable for Epic Games Launcher
-    export STEAM_COMPAT_DATA_PATH="$HOME/.local/share/Steam/steamapps/compatdata/${appid}"
+    export STEAM_COMPAT_DATA_PATH="${logged_in_home}/.local/share/Steam/steamapps/compatdata/${appid}"
 
     # Download EA App file
     if [ ! -f "$eaapp_file" ]; then
@@ -1902,18 +1913,18 @@ if [[ $options == *"itch.io"* ]]; then
     fi
 
     # Create app id folder in compatdata folder if it doesn't exist
-    if [ ! -d "$HOME/.local/share/Steam/steamapps/compatdata/$appid" ]; then
-        mkdir -p "$HOME/.local/share/Steam/steamapps/compatdata/$appid"
+    if [ ! -d "${logged_in_home}/.local/share/Steam/steamapps/compatdata/$appid" ]; then
+        mkdir -p "${logged_in_home}/.local/share/Steam/steamapps/compatdata/$appid"
     fi
 
     # Change working directory to Proton's
     cd $proton_dir
 
     # Set the STEAM_COMPAT_CLIENT_INSTALL_PATH environment variable
-    export STEAM_COMPAT_CLIENT_INSTALL_PATH="$HOME/.local/share/Steam"
+    export STEAM_COMPAT_CLIENT_INSTALL_PATH="${logged_in_home}/.local/share/Steam"
 
     # Set the STEAM_COMPAT_DATA_PATH environment variable for Epic Games Launcher
-    export STEAM_COMPAT_DATA_PATH="$HOME/.local/share/Steam/steamapps/compatdata/${appid}"
+    export STEAM_COMPAT_DATA_PATH="${logged_in_home}/.local/share/Steam/steamapps/compatdata/${appid}"
 
     # Download itchio file
     if [ ! -f "$itchio_file" ]; then
@@ -1943,18 +1954,18 @@ if [[ $options == *"Legacy Games"* ]]; then
     fi
 
     # Create app id folder in compatdata folder if it doesn't exist
-    if [ ! -d "$HOME/.local/share/Steam/steamapps/compatdata/$appid" ]; then
-        mkdir -p "$HOME/.local/share/Steam/steamapps/compatdata/$appid"
+    if [ ! -d "${logged_in_home}/.local/share/Steam/steamapps/compatdata/$appid" ]; then
+        mkdir -p "${logged_in_home}/.local/share/Steam/steamapps/compatdata/$appid"
     fi
 
     # Change working directory to Proton's
     cd $proton_dir
 
     # Set the STEAM_COMPAT_CLIENT_INSTALL_PATH environment variable
-    export STEAM_COMPAT_CLIENT_INSTALL_PATH="$HOME/.local/share/Steam"
+    export STEAM_COMPAT_CLIENT_INSTALL_PATH="${logged_in_home}/.local/share/Steam"
 
     # Set the STEAM_COMPAT_DATA_PATH environment variable for Legacy Games Launcher
-    export STEAM_COMPAT_DATA_PATH="$HOME/.local/share/Steam/steamapps/compatdata/${appid}"
+    export STEAM_COMPAT_DATA_PATH="${logged_in_home}/.local/share/Steam/steamapps/compatdata/${appid}"
 
     # Download Legacy file
     if [ ! -f "$legacygames_file" ]; then
@@ -1978,21 +1989,21 @@ if [[ $options == *"Humble Games Collection"* ]]; then
     # User selected Humble Games Launcher
     echo "User selected Humble Games Collection"
 
-    if [[ ! -f "$HOME/.local/share/applications/Humble-scheme-handler.desktop" ]]; then
+    if [[ ! -f "${logged_in_home}/.local/share/applications/Humble-scheme-handler.desktop" ]]; then
         wget https://raw.githubusercontent.com/moraroy/NonSteamLaunchers-On-Steam-Deck/main/humble-app/Humble-scheme-handler.desktop -O /tmp/Humble-scheme-handler.desktop
         sed -i "s/APPID/$appid/" /tmp/Humble-scheme-handler.desktop
-        desktop-file-install --rebuild-mime-info-cache --dir=$HOME/.local/share/applications /tmp/Humble-scheme-handler.desktop
+        desktop-file-install --rebuild-mime-info-cache --dir=${logged_in_home}/.local/share/applications /tmp/Humble-scheme-handler.desktop
         rm -rf /tmp/Humble-scheme-handler.desktop
     fi
 
-    if [[ ! -f "$HOME/.local/share/Steam/steamapps/compatdata/$appid/pfx/handle-humble-scheme" ]]; then
-        wget https://raw.githubusercontent.com/moraroy/NonSteamLaunchers-On-Steam-Deck/main/humble-app/handle-humble-scheme -O "$HOME/.local/share/Steam/steamapps/compatdata/$appid/pfx/handle-humble-scheme"
-        sed -i "s/APPID/$appid/" "$HOME/.local/share/Steam/steamapps/compatdata/$appid/pfx/handle-humble-scheme"
-        chmod +x "$HOME/.local/share/Steam/steamapps/compatdata/$appid/pfx/handle-humble-scheme"
+    if [[ ! -f "${logged_in_home}/.local/share/Steam/steamapps/compatdata/$appid/pfx/handle-humble-scheme" ]]; then
+        wget https://raw.githubusercontent.com/moraroy/NonSteamLaunchers-On-Steam-Deck/main/humble-app/handle-humble-scheme -O "${logged_in_home}/.local/share/Steam/steamapps/compatdata/$appid/pfx/handle-humble-scheme"
+        sed -i "s/APPID/$appid/" "${logged_in_home}/.local/share/Steam/steamapps/compatdata/$appid/pfx/handle-humble-scheme"
+        chmod +x "${logged_in_home}/.local/share/Steam/steamapps/compatdata/$appid/pfx/handle-humble-scheme"
     fi
 
-    if [[ ! -f "$HOME/.local/share/Steam/steamapps/compatdata/$appid/pfx/start-humble.cmd" ]]; then
-        wget https://raw.githubusercontent.com/moraroy/NonSteamLaunchers-On-Steam-Deck/main/humble-app/start-humble.cmd -O "$HOME/.local/share/Steam/steamapps/compatdata/$appid/pfx/start-humble.cmd"
+    if [[ ! -f "${logged_in_home}/.local/share/Steam/steamapps/compatdata/$appid/pfx/start-humble.cmd" ]]; then
+        wget https://raw.githubusercontent.com/moraroy/NonSteamLaunchers-On-Steam-Deck/main/humble-app/start-humble.cmd -O "${logged_in_home}/.local/share/Steam/steamapps/compatdata/$appid/pfx/start-humble.cmd"
     fi
 
     # Set the appid for the Humble Games Launcher
@@ -2003,18 +2014,18 @@ if [[ $options == *"Humble Games Collection"* ]]; then
     fi
 
     # Create app id folder in compatdata folder if it doesn't exist
-    if [ ! -d "$HOME/.local/share/Steam/steamapps/compatdata/$appid" ]; then
-        mkdir -p "$HOME/.local/share/Steam/steamapps/compatdata/$appid"
+    if [ ! -d "${logged_in_home}/.local/share/Steam/steamapps/compatdata/$appid" ]; then
+        mkdir -p "${logged_in_home}/.local/share/Steam/steamapps/compatdata/$appid"
     fi
 
     # Change working directory to Proton's
     cd $proton_dir
 
     # Set the STEAM_COMPAT_CLIENT_INSTALL_PATH environment variable
-    export STEAM_COMPAT_CLIENT_INSTALL_PATH="$HOME/.local/share/Steam"
+    export STEAM_COMPAT_CLIENT_INSTALL_PATH="${logged_in_home}/.local/share/Steam"
 
     # Set the STEAM_COMPAT_DATA_PATH environment variable for Humble Games Launcher
-    export STEAM_COMPAT_DATA_PATH="$HOME/.local/share/Steam/steamapps/compatdata/${appid}"
+    export STEAM_COMPAT_DATA_PATH="${logged_in_home}/.local/share/Steam/steamapps/compatdata/${appid}"
 
     # Download exe file
     if [ ! -f "$humblegames_file" ]; then
@@ -2044,18 +2055,18 @@ if [[ $options == *"IndieGala"* ]]; then
     fi
 
     # Create app id folder in compatdata folder if it doesn't exist
-    if [ ! -d "$HOME/.local/share/Steam/steamapps/compatdata/$appid" ]; then
-        mkdir -p "$HOME/.local/share/Steam/steamapps/compatdata/$appid"
+    if [ ! -d "${logged_in_home}/.local/share/Steam/steamapps/compatdata/$appid" ]; then
+        mkdir -p "${logged_in_home}/.local/share/Steam/steamapps/compatdata/$appid"
     fi
 
     # Change working directory to Proton's
     cd $proton_dir
 
     # Set the STEAM_COMPAT_CLIENT_INSTALL_PATH environment variable
-    export STEAM_COMPAT_CLIENT_INSTALL_PATH="$HOME/.local/share/Steam"
+    export STEAM_COMPAT_CLIENT_INSTALL_PATH="${logged_in_home}/.local/share/Steam"
 
     # Set the STEAM_COMPAT_DATA_PATH environment variable for Legacy Games Launcher
-    export STEAM_COMPAT_DATA_PATH="$HOME/.local/share/Steam/steamapps/compatdata/${appid}"
+    export STEAM_COMPAT_DATA_PATH="${logged_in_home}/.local/share/Steam/steamapps/compatdata/${appid}"
 
     # Download indiegala file
     if [ ! -f "$indiegala_file" ]; then
@@ -2087,18 +2098,18 @@ if [[ $options == *"Rockstar Games Launcher"* ]]; then
     fi
 
     # Create app id folder in compatdata folder if it doesn't exist
-    if [ ! -d "$HOME/.local/share/Steam/steamapps/compatdata/$appid" ]; then
-        mkdir -p "$HOME/.local/share/Steam/steamapps/compatdata/$appid"
+    if [ ! -d "${logged_in_home}/.local/share/Steam/steamapps/compatdata/$appid" ]; then
+        mkdir -p "${logged_in_home}/.local/share/Steam/steamapps/compatdata/$appid"
     fi
 
     # Change working directory to Proton's
     cd $proton_dir
 
     # Set the STEAM_COMPAT_CLIENT_INSTALL_PATH environment variable
-    export STEAM_COMPAT_CLIENT_INSTALL_PATH="$HOME/.local/share/Steam"
+    export STEAM_COMPAT_CLIENT_INSTALL_PATH="${logged_in_home}/.local/share/Steam"
 
     # Set the STEAM_COMPAT_DATA_PATH environment variable for Legacy Games Launcher
-    export STEAM_COMPAT_DATA_PATH="$HOME/.local/share/Steam/steamapps/compatdata/${appid}"
+    export STEAM_COMPAT_DATA_PATH="${logged_in_home}/.local/share/Steam/steamapps/compatdata/${appid}"
 
     # Download rockstar games file
     if [ ! -f "$rockstar_file" ]; then
@@ -2130,18 +2141,18 @@ if [[ $options == *"Glyph Launcher"* ]]; then
     fi
 
     # Create app id folder in compatdata folder if it doesn't exist
-    if [ ! -d "$HOME/.local/share/Steam/steamapps/compatdata/$appid" ]; then
-        mkdir -p "$HOME/.local/share/Steam/steamapps/compatdata/$appid"
+    if [ ! -d "${logged_in_home}/.local/share/Steam/steamapps/compatdata/$appid" ]; then
+        mkdir -p "${logged_in_home}/.local/share/Steam/steamapps/compatdata/$appid"
     fi
 
     # Change working directory to Proton's
     cd $proton_dir
 
     # Set the STEAM_COMPAT_CLIENT_INSTALL_PATH environment variable
-    export STEAM_COMPAT_CLIENT_INSTALL_PATH="$HOME/.local/share/Steam"
+    export STEAM_COMPAT_CLIENT_INSTALL_PATH="${logged_in_home}/.local/share/Steam"
 
     # Set the STEAM_COMPAT_DATA_PATH environment variable for Legacy Games Launcher
-    export STEAM_COMPAT_DATA_PATH="$HOME/.local/share/Steam/steamapps/compatdata/${appid}"
+    export STEAM_COMPAT_DATA_PATH="${logged_in_home}/.local/share/Steam/steamapps/compatdata/${appid}"
 
     # Download Glyph file
     if [ ! -f "$glyph_file" ]; then
@@ -2173,21 +2184,21 @@ if [[ $options == *"Minecraft"* ]]; then
     fi
 
     # Set MinecraftLauncher.exe Variable
-    minecraftinstall_path="$HOME/.local/share/Steam/steamapps/compatdata/$appid/pfx/drive_c/Program Files (x86)/Minecraft Launcher/MinecraftLauncher.exe"
+    minecraftinstall_path="${logged_in_home}/.local/share/Steam/steamapps/compatdata/$appid/pfx/drive_c/Program Files (x86)/Minecraft Launcher/MinecraftLauncher.exe"
 
     # Create app id folder in compatdata folder if it doesn't exist
-    if [ ! -d "$HOME/.local/share/Steam/steamapps/compatdata/$appid" ]; then
-        mkdir -p "$HOME/.local/share/Steam/steamapps/compatdata/$appid"
+    if [ ! -d "${logged_in_home}/.local/share/Steam/steamapps/compatdata/$appid" ]; then
+        mkdir -p "${logged_in_home}/.local/share/Steam/steamapps/compatdata/$appid"
     fi
 
     # Change working directory to Proton's
     cd $proton_dir
 
     # Set the STEAM_COMPAT_CLIENT_INSTALL_PATH environment variable
-    export STEAM_COMPAT_CLIENT_INSTALL_PATH="$HOME/.local/share/Steam"
+    export STEAM_COMPAT_CLIENT_INSTALL_PATH="${logged_in_home}/.local/share/Steam"
 
     # Set the STEAM_COMPAT_DATA_PATH environment variable for Legacy Games Launcher
-    export STEAM_COMPAT_DATA_PATH="$HOME/.local/share/Steam/steamapps/compatdata/${appid}"
+    export STEAM_COMPAT_DATA_PATH="${logged_in_home}/.local/share/Steam/steamapps/compatdata/${appid}"
 
     # Download Minecraft file
     if [ ! -f "$minecraft_file" ]; then
@@ -2228,18 +2239,18 @@ if [[ $options == *"Playstation Plus"* ]]; then
     fi
 
     # Create app id folder in compatdata folder if it doesn't exist
-    if [ ! -d "$HOME/.local/share/Steam/steamapps/compatdata/$appid" ]; then
-        mkdir -p "$HOME/.local/share/Steam/steamapps/compatdata/$appid"
+    if [ ! -d "${logged_in_home}/.local/share/Steam/steamapps/compatdata/$appid" ]; then
+        mkdir -p "${logged_in_home}/.local/share/Steam/steamapps/compatdata/$appid"
     fi
 
     # Change working directory to Proton's
     cd $proton_dir
 
     # Set the STEAM_COMPAT_CLIENT_INSTALL_PATH environment variable
-    export STEAM_COMPAT_CLIENT_INSTALL_PATH="$HOME/.local/share/Steam"
+    export STEAM_COMPAT_CLIENT_INSTALL_PATH="${logged_in_home}/.local/share/Steam"
 
     # Set the STEAM_COMPAT_DATA_PATH environment variable for Epic Games Launcher
-    export STEAM_COMPAT_DATA_PATH="$HOME/.local/share/Steam/steamapps/compatdata/${appid}"
+    export STEAM_COMPAT_DATA_PATH="${logged_in_home}/.local/share/Steam/steamapps/compatdata/${appid}"
 
     # Download MSI file
     if [ ! -f "$psplus_file" ]; then
@@ -2270,18 +2281,18 @@ if [[ $options == *"DMM Games"* ]]; then
     fi
 
     # Create app id folder in compatdata folder if it doesn't exist
-    if [ ! -d "$HOME/.local/share/Steam/steamapps/compatdata/$appid" ]; then
-        mkdir -p "$HOME/.local/share/Steam/steamapps/compatdata/$appid"
+    if [ ! -d "${logged_in_home}/.local/share/Steam/steamapps/compatdata/$appid" ]; then
+        mkdir -p "${logged_in_home}/.local/share/Steam/steamapps/compatdata/$appid"
     fi
 
     # Change working directory to Proton's
     cd $proton_dir
 
     # Set the STEAM_COMPAT_CLIENT_INSTALL_PATH environment variable
-    export STEAM_COMPAT_CLIENT_INSTALL_PATH="$HOME/.local/share/Steam"
+    export STEAM_COMPAT_CLIENT_INSTALL_PATH="${logged_in_home}/.local/share/Steam"
 
     # Set the STEAM_COMPAT_DATA_PATH environment variable for Epic Games Launcher
-    export STEAM_COMPAT_DATA_PATH="$HOME/.local/share/Steam/steamapps/compatdata/${appid}"
+    export STEAM_COMPAT_DATA_PATH="${logged_in_home}/.local/share/Steam/steamapps/compatdata/${appid}"
 
     # Download DMM file
     if [ ! -f "$dmm_file" ]; then
@@ -2322,7 +2333,7 @@ fi
 wait
 
 # Delete NonSteamLaunchersInstallation subfolder in Downloads folder
-rm -rf "$HOME/Downloads/NonSteamLaunchersInstallation"
+rm -rf "${logged_in_home}/Downloads/NonSteamLaunchersInstallation"
 
     echo "100"
     echo "# Installation Complete - Steam will now restart. Your launchers will be in your library!...Food for thought...do Jedis use Force Compatability?"
@@ -2338,192 +2349,192 @@ wait
 if [[ -f "$epic_games_launcher_path1" ]]; then
     # Epic Games Launcher is installed at path 1
     epicshortcutdirectory="\"$epic_games_launcher_path1\""
-    epiclaunchoptions="STEAM_COMPAT_DATA_PATH=\"$HOME/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/\" %command%"
+    epiclaunchoptions="STEAM_COMPAT_DATA_PATH=\"${logged_in_home}/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/\" %command%"
     epicstartingdir="\"$(dirname "$epic_games_launcher_path1")\""
 elif [[ -f "$epic_games_launcher_path2" ]]; then
     # Epic Games Launcher is installed at path 2
     epicshortcutdirectory="\"$epic_games_launcher_path2\""
-    epiclaunchoptions="STEAM_COMPAT_DATA_PATH=\"$HOME/.local/share/Steam/steamapps/compatdata/EpicGamesLauncher/\" %command%"
+    epiclaunchoptions="STEAM_COMPAT_DATA_PATH=\"${logged_in_home}/.local/share/Steam/steamapps/compatdata/EpicGamesLauncher/\" %command%"
     epicstartingdir="\"$(dirname "$epic_games_launcher_path2")\""
 fi
 
 if [[ -f "$gog_galaxy_path1" ]]; then
     # Gog Galaxy Launcher is installed at path 1
     gogshortcutdirectory="\"$gog_galaxy_path1\""
-    goglaunchoptions="STEAM_COMPAT_DATA_PATH=\"$HOME/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/\" %command%"
+    goglaunchoptions="STEAM_COMPAT_DATA_PATH=\"${logged_in_home}/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/\" %command%"
     gogstartingdir="\"$(dirname "$gog_galaxy_path1")\""
 elif [[ -f "$gog_galaxy_path2" ]]; then
     # Gog Galaxy Launcher is installed at path 2
     gogshortcutdirectory="\"$gog_galaxy_path2\""
-    goglaunchoptions="STEAM_COMPAT_DATA_PATH=\"$HOME/.local/share/Steam/steamapps/compatdata/GogGalaxyLauncher/\" %command%"
+    goglaunchoptions="STEAM_COMPAT_DATA_PATH=\"${logged_in_home}/.local/share/Steam/steamapps/compatdata/GogGalaxyLauncher/\" %command%"
     gogstartingdir="\"$(dirname "$gog_galaxy_path2")\""
 fi
 
 if [[ -f "$origin_path1" ]]; then
     # Origin Launcher is installed at path 1
     originshortcutdirectory="\"$origin_path1\""
-    originlaunchoptions="STEAM_COMPAT_DATA_PATH=\"$HOME/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/\" %command%"
+    originlaunchoptions="STEAM_COMPAT_DATA_PATH=\"${logged_in_home}/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/\" %command%"
     originstartingdir="\"$(dirname "$origin_path1")\""
 elif [[ -f "$origin_path2" ]]; then
     # Origin Launcher is installed at path 2
     originshortcutdirectory="\"$origin_path2\""
-    originlaunchoptions="STEAM_COMPAT_DATA_PATH=\"$HOME/.local/share/Steam/steamapps/compatdata/OriginLauncher/\" %command%"
+    originlaunchoptions="STEAM_COMPAT_DATA_PATH=\"${logged_in_home}/.local/share/Steam/steamapps/compatdata/OriginLauncher/\" %command%"
     originstartingdir="\"$(dirname "$origin_path2")\""
 fi
 
 if [[ -f "$uplay_path1" ]]; then
     # Uplay Launcher is installed at path 1
     uplayshortcutdirectory="\"$uplay_path1\""
-    uplaylaunchoptions="STEAM_COMPAT_DATA_PATH=\"$HOME/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/\" %command%"
+    uplaylaunchoptions="STEAM_COMPAT_DATA_PATH=\"${logged_in_home}/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/\" %command%"
     uplaystartingdir="\"$(dirname "$uplay_path1")\""
 elif [[ -f "$uplay_path2" ]]; then
     # Uplay Launcher is installed at path 2
     uplayshortcutdirectory="\"$uplay_path2\""
-    uplaylaunchoptions="STEAM_COMPAT_DATA_PATH=\"$HOME/.local/share/Steam/steamapps/compatdata/UplayLauncher/\" %command%"
+    uplaylaunchoptions="STEAM_COMPAT_DATA_PATH=\"${logged_in_home}/.local/share/Steam/steamapps/compatdata/UplayLauncher/\" %command%"
     uplaystartingdir="\"$(dirname "$uplay_path2")\""
 fi
 
 if [[ -f "$battlenet_path1" ]]; then
     # Battlenet Launcher is installed at path 1
     battlenetshortcutdirectory="\"$battlenet_path1\""
-    battlenetlaunchoptions="STEAM_COMPAT_DATA_PATH=\"$HOME/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/\" %command%"
+    battlenetlaunchoptions="STEAM_COMPAT_DATA_PATH=\"${logged_in_home}/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/\" %command%"
     battlenetstartingdir="\"$(dirname "$battlenet_path1")\""
 elif [[ -f "$battlenet_path2" ]]; then
     # Battlenet Launcher is installed at path 2
     battlenetshortcutdirectory="\"$battlenet_path2\""
-    battlenetlaunchoptions="STEAM_COMPAT_DATA_PATH=\"$HOME/.local/share/Steam/steamapps/compatdata/Battle.netLauncher/\" %command%"
+    battlenetlaunchoptions="STEAM_COMPAT_DATA_PATH=\"${logged_in_home}/.local/share/Steam/steamapps/compatdata/Battle.netLauncher/\" %command%"
     battlenetstartingdir="\"$(dirname "$battlenet_path2")\""
 fi
 
 if [[ -f "$eaapp_path1" ]]; then
     # EA App Launcher is installed at path 1
     eaappshortcutdirectory="\"$eaapp_path1\""
-    eaapplaunchoptions="STEAM_COMPAT_DATA_PATH=\"$HOME/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/\" %command%"
+    eaapplaunchoptions="STEAM_COMPAT_DATA_PATH=\"${logged_in_home}/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/\" %command%"
     eaappstartingdir="\"$(dirname "$eaapp_path1")\""
 elif [[ -f "$eaapp_path2" ]]; then
     # EA App Launcher is installed at path 2
     eaappshortcutdirectory="\"$eaapp_path2\""
-    eaapplaunchoptions="STEAM_COMPAT_DATA_PATH=\"$HOME/.local/share/Steam/steamapps/compatdata/TheEAappLauncher/\" %command%"
+    eaapplaunchoptions="STEAM_COMPAT_DATA_PATH=\"${logged_in_home}/.local/share/Steam/steamapps/compatdata/TheEAappLauncher/\" %command%"
     eaappstartingdir="\"$(dirname "$eaapp_path2")\""
 fi
 
 if [[ -f "$amazongames_path1" ]]; then
     # Amazon Games Launcher is installed at path 1
     amazonshortcutdirectory="\"$amazongames_path1\""
-    amazonlaunchoptions="STEAM_COMPAT_DATA_PATH=\"$HOME/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/\" %command%"
+    amazonlaunchoptions="STEAM_COMPAT_DATA_PATH=\"${logged_in_home}/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/\" %command%"
     amazonstartingdir="\"$(dirname "$amazongames_path1")\""
 elif [[ -f "$amazongames_path2" ]]; then
     # Amazon Games Launcher is installed at path 2
     amazonshortcutdirectory="\"$amazongames_path2\""
-    amazonlaunchoptions="STEAM_COMPAT_DATA_PATH=\"$HOME/.local/share/Steam/steamapps/compatdata/AmazonGamesLauncher/\" %command%"
+    amazonlaunchoptions="STEAM_COMPAT_DATA_PATH=\"${logged_in_home}/.local/share/Steam/steamapps/compatdata/AmazonGamesLauncher/\" %command%"
     amazonstartingdir="\"$(dirname "$amazongames_path2")\""
 fi
 
 if [[ -f "$itchio_path1" ]]; then
     # itchio Launcher is installed at path 1
     itchioshortcutdirectory="\"$itchio_path1\""
-    itchiolaunchoptions="STEAM_COMPAT_DATA_PATH=\"$HOME/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/\" %command%"
+    itchiolaunchoptions="STEAM_COMPAT_DATA_PATH=\"${logged_in_home}/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/\" %command%"
     itchiostartingdir="\"$(dirname "$itchio_path1")\""
 elif [[ -f "$itchio_path2" ]]; then
     # itchio Launcher is installed at path 2
     itchioshortcutdirectory="\"$itchio_path2\""
-    itchiolaunchoptions="STEAM_COMPAT_DATA_PATH=\"$HOME/.local/share/Steam/steamapps/compatdata/itchioLauncher/\" %command%"
+    itchiolaunchoptions="STEAM_COMPAT_DATA_PATH=\"${logged_in_home}/.local/share/Steam/steamapps/compatdata/itchioLauncher/\" %command%"
     itchiostartingdir="\"$(dirname "$itchio_path2")\""
 fi
 
 if [[ -f "$legacygames_path1" ]]; then
     # Legacy Games Launcher is installed at path 1
     legacyshortcutdirectory="\"$legacygames_path1\""
-    legacylaunchoptions="STEAM_COMPAT_DATA_PATH=\"$HOME/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/\" %command%"
+    legacylaunchoptions="STEAM_COMPAT_DATA_PATH=\"${logged_in_home}/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/\" %command%"
     legacystartingdir="\"$(dirname "$legacygames_path1")\""
 elif [[ -f "$legacygames_path2" ]]; then
     # Legacy Games Launcher is installed at path 2
     legacyshortcutdirectory="\"$legacygames_path2\""
-    legacylaunchoptions="STEAM_COMPAT_DATA_PATH=\"$HOME/.local/share/Steam/steamapps/compatdata/LegacyGamesLauncher/\" %command%"
+    legacylaunchoptions="STEAM_COMPAT_DATA_PATH=\"${logged_in_home}/.local/share/Steam/steamapps/compatdata/LegacyGamesLauncher/\" %command%"
     legacystartingdir="\"$(dirname "$legacygames_path2")\""
 fi
 
 if [[ -f "$humblegames_path1" ]]; then
     # Humble Games Launcher is installed at path 1
     humbleshortcutdirectory="\"$humblegames_path1\""
-    humblelaunchoptions="STEAM_COMPAT_DATA_PATH=\"$HOME/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/\" %command%"
+    humblelaunchoptions="STEAM_COMPAT_DATA_PATH=\"${logged_in_home}/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/\" %command%"
     humblestartingdir="\"$(dirname "$humblegames_path1")\""
 elif [[ -f "$humblegames_path2" ]]; then
     # Humble Games Launcher is installed at path 2
     humbleshortcutdirectory="\"$humblegames_path2\""
-    humblelaunchoptions="STEAM_COMPAT_DATA_PATH=\"$HOME/.local/share/Steam/steamapps/compatdata/HumbleGamesLauncher/\" %command%"
+    humblelaunchoptions="STEAM_COMPAT_DATA_PATH=\"${logged_in_home}/.local/share/Steam/steamapps/compatdata/HumbleGamesLauncher/\" %command%"
     humblestartingdir="\"$(dirname "$humblegames_path2")\""
 fi
 
 if [[ -f "$indiegala_path1" ]]; then
     # indiegala Launcher is installed at path 1
     indieshortcutdirectory="\"$indiegala_path1\""
-    indielaunchoptions="STEAM_COMPAT_DATA_PATH=\"$HOME/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/\" %command%"
+    indielaunchoptions="STEAM_COMPAT_DATA_PATH=\"${logged_in_home}/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/\" %command%"
     indiestartingdir="\"$(dirname "$indiegala_path1")\""
 elif [[ -f "$indiegala_path2" ]]; then
     # indiegala Launcher is installed at path 2
     indieshortcutdirectory="\"$indiegala_path2\""
-    indielaunchoptions="STEAM_COMPAT_DATA_PATH=\"$HOME/.local/share/Steam/steamapps/compatdata/IndieGalaLauncher/\" %command%"
+    indielaunchoptions="STEAM_COMPAT_DATA_PATH=\"${logged_in_home}/.local/share/Steam/steamapps/compatdata/IndieGalaLauncher/\" %command%"
     indiestartingdir="\"$(dirname "$indiegala_path2")\""
 fi
 
 if [[ -f "$rockstar_path1" ]]; then
     # rockstar Launcher is installed at path 1
     rockstarshortcutdirectory="\"$rockstar_path1\""
-    rockstarlaunchoptions="STEAM_COMPAT_DATA_PATH=\"$HOME/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/\" %command%"
+    rockstarlaunchoptions="STEAM_COMPAT_DATA_PATH=\"${logged_in_home}/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/\" %command%"
     rockstarstartingdir="\"$(dirname "$rockstar_path1")\""
 elif [[ -f "$rockstar_path2" ]]; then
     # rockstar Launcher is installed at path 2
     rockstarshortcutdirectory="\"$rockstar_path2\""
-    rockstarlaunchoptions="STEAM_COMPAT_DATA_PATH=\"$HOME/.local/share/Steam/steamapps/compatdata/RockstarGamesLauncher/\" %command%"
+    rockstarlaunchoptions="STEAM_COMPAT_DATA_PATH=\"${logged_in_home}/.local/share/Steam/steamapps/compatdata/RockstarGamesLauncher/\" %command%"
     rockstarstartingdir="\"$(dirname "$rockstar_path2")\""
 fi
 
 if [[ -f "$glyph_path1" ]]; then
     # Glyph is installed at path 1
     glyphshortcutdirectory="\"$glyph_path1\""
-    glyphlaunchoptions="STEAM_COMPAT_DATA_PATH=\"$HOME/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/\" %command%"
+    glyphlaunchoptions="STEAM_COMPAT_DATA_PATH=\"${logged_in_home}/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/\" %command%"
     glyphstartingdir="\"$(dirname "$glyph_path1")\""
 elif [[ -f "$glyph_path2" ]]; then
     # Glyph is installed at path 2
     glyphshortcutdirectory="\"$glyph_path2\""
-    glyphlaunchoptions="STEAM_COMPAT_DATA_PATH=\"$HOME/.local/share/Steam/steamapps/compatdata/GlyphLauncher/\" %command%"
+    glyphlaunchoptions="STEAM_COMPAT_DATA_PATH=\"${logged_in_home}/.local/share/Steam/steamapps/compatdata/GlyphLauncher/\" %command%"
     glyphstartingdir="\"$(dirname "$glyph_path2")\""
 fi
 
 if [[ -f "$minecraft_path1" ]]; then
     # Minecraft is installed at path 1
     minecraftshortcutdirectory="\"$minecraft_path1\""
-    minecraftlaunchoptions="STEAM_COMPAT_DATA_PATH=\"$HOME/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/\" %command%"
+    minecraftlaunchoptions="STEAM_COMPAT_DATA_PATH=\"${logged_in_home}/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/\" %command%"
     minecraftstartingdir="\"$(dirname "$minecraft_path1")\""
 elif [[ -f "$minecraft_path2" ]]; then
     # Minecraft is installed at path 2
     minecraftshortcutdirectory="\"$minecraft_path2\""
-    minecraftlaunchoptions="STEAM_COMPAT_DATA_PATH=\"$HOME/.local/share/Steam/steamapps/compatdata/MinecraftLauncher/\" %command%"
+    minecraftlaunchoptions="STEAM_COMPAT_DATA_PATH=\"${logged_in_home}/.local/share/Steam/steamapps/compatdata/MinecraftLauncher/\" %command%"
     minecraftstartingdir="\"$(dirname "$minecraft_path1")\""
 fi
 
 if [[ -f "$psplus_path1" ]]; then
     # Playstation is installed at path 1
     psplusshortcutdirectory="\"$psplus_path1\""
-    pspluslaunchoptions="STEAM_COMPAT_DATA_PATH=\"$HOME/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/\" %command%"
+    pspluslaunchoptions="STEAM_COMPAT_DATA_PATH=\"${logged_in_home}/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/\" %command%"
     psplusstartingdir="\"$(dirname "$psplus_path1")\""
 elif [[ -f "$psplus_path2" ]]; then
     # Playstation is installed at path 2
     psplusshortcutdirectory="\"$psplus_path2\""
-    pspluslaunchoptions="STEAM_COMPAT_DATA_PATH=\"$HOME/.local/share/Steam/steamapps/compatdata/PlaystationPlusLauncher/\" %command%"
+    pspluslaunchoptions="STEAM_COMPAT_DATA_PATH=\"${logged_in_home}/.local/share/Steam/steamapps/compatdata/PlaystationPlusLauncher/\" %command%"
     psplusstartingdir="\"$(dirname "$psplus_path2")\""
 fi
 
 if [[ -f "$dmm_path1" ]]; then
     # DMM Games is installed at path 1
     dmmshortcutdirectory="\"$dmm_path1\""
-    dmmlaunchoptions="STEAM_COMPAT_DATA_PATH=\"$HOME/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/\" %command%"
+    dmmlaunchoptions="STEAM_COMPAT_DATA_PATH=\"${logged_in_home}/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/\" %command%"
     dmmstartingdir="\"$(dirname "$dmm_path1")\""
 elif [[ -f "$dmm_path2" ]]; then
     # DMM Player is installed at path 2
     dmmshortcutdirectory="\"$dmm_path2\""
-    dmmlaunchoptions="STEAM_COMPAT_DATA_PATH=\"$HOME/.local/share/Steam/steamapps/compatdata/DMMGameLauncher/\" %command%"
+    dmmlaunchoptions="STEAM_COMPAT_DATA_PATH=\"${logged_in_home}/.local/share/Steam/steamapps/compatdata/DMMGameLauncher/\" %command%"
     dmmstartingdir="\"$(dirname "$dmm_path2")\""
 fi
 
@@ -2631,7 +2642,7 @@ wget -P "$download_dir/lib/python$python_version/site-packages/vdf" "$download_u
 export PYTHONPATH="$download_dir/lib/python$python_version/site-packages/:$PYTHONPATH"
 
 # Set the default Steam directory
-steam_dir="$HOME/.local/share/Steam"
+steam_dir="${logged_in_home}/.local/share/Steam"
 
 # Check if the config.vdf file exists
 if [[ -f "$steam_dir/config/config.vdf" ]]; then
@@ -2724,7 +2735,7 @@ while pgrep steam > /dev/null; do sleep 1; done
 # Pre check for updating the config file
 
 # Set the default Steam directory
-steam_dir="$HOME/.steam/root"
+steam_dir="${logged_in_home}/.steam/root"
 
 # Set the path to the config.vdf file
 config_vdf_path="$steam_dir/config/config.vdf"
@@ -2742,7 +2753,7 @@ else
 fi
 
 # Set the path to the configset_controller_neptune.vdf file
-controller_config_path="$HOME/.local/share/Steam/steamapps/common/Steam Controller Configs/$steamid3/config/configset_controller_neptune.vdf"
+controller_config_path="${logged_in_home}/.local/share/Steam/steamapps/common/Steam Controller Configs/$steamid3/config/configset_controller_neptune.vdf"
 
 # Check if the configset_controller_neptune.vdf file exists
 if [[ -f "$controller_config_path" ]]; then
@@ -2759,7 +2770,7 @@ python3 -c "
 import sys
 import os
 import subprocess
-sys.path.insert(0, os.path.expanduser('$HOME/Downloads/NonSteamLaunchersInstallation/lib/python$python_version/site-packages'))
+sys.path.insert(0, os.path.expanduser('${logged_in_home}/Downloads/NonSteamLaunchersInstallation/lib/python$python_version/site-packages'))
 print(sys.path)  # Add this line to print the value of sys.path
 import vdf  # Updated import
 import binascii
@@ -3060,7 +3071,7 @@ with open('$controller_config_path', 'w') as f:
     vdf.dump(config, f)
 
 # Define the path to the compatdata directory
-compatdata_dir = '$HOME/.local/share/Steam/steamapps/compatdata'
+compatdata_dir = '${logged_in_home}/.local/share/Steam/steamapps/compatdata'
 
 # Define a dictionary of original folder names
 folder_names = {

--- a/NonSteamLaunchers.sh
+++ b/NonSteamLaunchers.sh
@@ -53,12 +53,12 @@ logged_in_home=$(eval echo "~${logged_in_user}")
 
 # TODO: `/tmp` or `mktemp -d` might be a better option (see: EOF)
 # $PWD (working directory)
-install_dir="${logged_in_home}/Downloads/NonSteamLaunchersInstallation"
+download_dir="${logged_in_home}/Downloads/NonSteamLaunchersInstallation"
 
 # Check if the NonSteamLaunchersInstallation subfolder exists in the Downloads folder
-if [ -d "$install_dir" ]; then
+if [ -d "$download_dir" ]; then
     # Delete the NonSteamLaunchersInstallation subfolder
-    rm -rf "$install_dir"
+    rm -rf "$download_dir"
     echo "Deleted NonSteamLaunchersInstallation subfolder"
 else
     echo "NonSteamLaunchersInstallation subfolder does not exist"
@@ -708,7 +708,7 @@ function StartFreshFunction {
     rm -rf "/run/media/mmcblk0p1/MinecraftLauncher/"
     rm -rf "/run/media/mmcblk0p1/PlaystationPlusLauncher/"
     rm -rf "/run/media/mmcblk0p1/DMMGameLauncher/"
-    rm -rf ~/Downloads/NonSteamLaunchersInstallation
+    rm -rf ${logged_in_home}/Downloads/NonSteamLaunchersInstallation
 
     # Exit the script with exit code 0 to indicate success
     exit 0
@@ -1309,14 +1309,14 @@ fi
 if [[ $options == "Find Games" ]]; then
     # The Find Games button was clicked
     # Check if the NonSteamLaunchersInstallation directory exists
-    if [[ ! -d "$install_dir" ]]; then
+    if [[ ! -d "$download_dir" ]]; then
         # The directory does not exist, so create it
-        mkdir -p "$install_dir"
+        mkdir -p "$download_dir"
     fi
 
     # Download the latest BoilR from GitHub (Linux version)
-    mkdir -p "$install_dir"
-    cd "$install_dir"
+    mkdir -p "$download_dir"
+    cd "$download_dir"
     wget https://github.com/PhilipK/BoilR/releases/download/v.1.9.1/linux_BoilR
 
     # Add execute permissions to the linux_BoilR file
@@ -1343,7 +1343,7 @@ echo "# Detecting, Updating and Installing GE-Proton"
 fi
 
 # Create NonSteamLaunchersInstallation subfolder in Downloads folder
-mkdir -p ~/Downloads/NonSteamLaunchersInstallation
+mkdir -p ${logged_in_home}/Downloads/NonSteamLaunchersInstallation
 
 # Set the path to the Proton directory
 proton_dir=$(find ~/.steam/root/compatibilitytools.d -maxdepth 1 -type d -name "GE-Proton*" | sort -V | tail -n1)
@@ -1356,20 +1356,20 @@ ge_proton_url2=https://github.com/GloriousEggroll/proton-ge-custom/releases/down
 if [ -z "$proton_dir" ]; then
     # Download GE-Proton using the first URL
     echo "Downloading GE-Proton using the first URL"
-    wget $ge_proton_url1 -O ~/Downloads/NonSteamLaunchersInstallation/GE-Proton.tar.gz
+    wget $ge_proton_url1 -O ${logged_in_home}/Downloads/NonSteamLaunchersInstallation/GE-Proton.tar.gz
 
     # Check if the download succeeded
     if [ $? -ne 0 ]; then
         # Download GE-Proton using the second URL
         echo "Downloading GE-Proton using the second URL"
-        wget $ge_proton_url2 -O ~/Downloads/NonSteamLaunchersInstallation/GE-Proton.tar.gz
+        wget $ge_proton_url2 -O ${logged_in_home}/Downloads/NonSteamLaunchersInstallation/GE-Proton.tar.gz
     fi
 
     # Check if either download succeeded
     if [ $? -eq 0 ]; then
         # Install GE-Proton
         echo "Installing GE-Proton"
-        tar -xvf ~/Downloads/NonSteamLaunchersInstallation/GE-Proton.tar.gz -C ~/.steam/root/compatibilitytools.d/
+        tar -xvf ${logged_in_home}/Downloads/NonSteamLaunchersInstallation/GE-Proton.tar.gz -C ~/.steam/root/compatibilitytools.d/
         proton_dir=$(find ~/.steam/root/compatibilitytools.d -maxdepth 1 -type d -name "GE-Proton*" | sort -V | tail -n1)
     else
         # Handle download failure
@@ -1383,20 +1383,20 @@ installed_version=$(basename $proton_dir | sed 's/GE-Proton-//')
     if [ "$installed_version" != "$latest_version" ]; then
         # Download GE-Proton using the first URL
         echo "Downloading GE-Proton using the first URL"
-        wget $ge_proton_url1 -O ~/Downloads/NonSteamLaunchersInstallation/GE-Proton.tar.gz
+        wget $ge_proton_url1 -O ${logged_in_home}/Downloads/NonSteamLaunchersInstallation/GE-Proton.tar.gz
 
         # Check if the download succeeded
         if [ $? -ne 0 ]; then
             # Download GE-Proton using the second URL
             echo "Downloading GE-Proton using the second URL"
-            wget $ge_proton_url2 -O ~/Downloads/NonSteamLaunchersInstallation/GE-Proton.tar.gz
+            wget $ge_proton_url2 -O ${logged_in_home}/Downloads/NonSteamLaunchersInstallation/GE-Proton.tar.gz
         fi
 
         # Check if either download succeeded
         if [ $? -eq 0 ]; then
             # Install GE-Proton
             echo "Installing GE-Proton"
-            tar -xvf ~/Downloads/NonSteamLaunchersInstallation/GE-Proton.tar.gz -C ~/.steam/root/compatibilitytools.d/
+            tar -xvf ${logged_in_home}/Downloads/NonSteamLaunchersInstallation/GE-Proton.tar.gz -C ~/.steam/root/compatibilitytools.d/
             proton_dir=$(find ~/.steam/root/compatibilitytools.d -maxdepth 1 -type d -name "GE-Proton*" | sort -V | tail -n1)
         else
             # Handle download failure
@@ -1415,97 +1415,97 @@ appid=NonSteamLaunchers
 msi_url=https://launcher-public-service-prod06.ol.epicgames.com/launcher/api/installer/download/EpicGamesLauncherInstaller.msi
 
 # Set the path to save the MSI file to
-msi_file=~/Downloads/NonSteamLaunchersInstallation/EpicGamesLauncherInstaller.msi
+msi_file=${logged_in_home}/Downloads/NonSteamLaunchersInstallation/EpicGamesLauncherInstaller.msi
 
 # Set the URL to download the second file from
 exe_url=https://webinstallers.gog-statics.com/download/GOG_Galaxy_2.0.exe
 
 # Set the path to save the second file to
-exe_file=~/Downloads/NonSteamLaunchersInstallation/GOG_Galaxy_2.0.exe
+exe_file=${logged_in_home}/Downloads/NonSteamLaunchersInstallation/GOG_Galaxy_2.0.exe
 
 # Set the URL to download the third file from
 ubi_url=https://ubi.li/4vxt9
 
 # Set the path to save the third file to
-ubi_file=~/Downloads/NonSteamLaunchersInstallation/UplayInstaller.exe
+ubi_file=${logged_in_home}/Downloads/NonSteamLaunchersInstallation/UplayInstaller.exe
 
 # Set the URL to download the fourth file from
 origin_url=https://eaassets-a.akamaihd.net/Origin-Client-Download/origin/live/OriginThinSetup.exe
 
 # Set the path to save the fourth file to
-origin_file=~/Downloads/NonSteamLaunchersInstallation/OriginThinSetup.exe
+origin_file=${logged_in_home}/Downloads/NonSteamLaunchersInstallation/OriginThinSetup.exe
 
 # Set the URL to download the fifth file from
 battle_url="https://www.battle.net/download/getInstallerForGame?os=win&gameProgram=BATTLENET_APP&version=Live"
 
 # Set the path to save the fifth file to
-battle_file=~/Downloads/NonSteamLaunchersInstallation/Battle.net-Setup.exe
+battle_file=${logged_in_home}/Downloads/NonSteamLaunchersInstallation/Battle.net-Setup.exe
 
 # Set the URL to download the sixth file from
 amazon_url=https://download.amazongames.com/AmazonGamesSetup.exe
 
 # Set the path to save the sixth file to
-amazon_file=~/Downloads/NonSteamLaunchersInstallation/AmazonGamesSetup.exe
+amazon_file=${logged_in_home}/Downloads/NonSteamLaunchersInstallation/AmazonGamesSetup.exe
 
 # Set the URL to download the seventh file from
 eaapp_url=https://origin-a.akamaihd.net/EA-Desktop-Client-Download/installer-releases/EAappInstaller.exe
 
 # Set the path to save the seventh file to
-eaapp_file=~/Downloads/NonSteamLaunchersInstallation/EAappInstaller.exe
+eaapp_file=${logged_in_home}/Downloads/NonSteamLaunchersInstallation/EAappInstaller.exe
 
 # Set the URL to download the eighth file from
 itchio_url=https://itch.io/app/download?platform=windows
 
 # Set the path to save the eighth file to
-itchio_file=~/Downloads/NonSteamLaunchersInstallation/itch-setup.exe
+itchio_file=${logged_in_home}/Downloads/NonSteamLaunchersInstallation/itch-setup.exe
 
 # Set the URL to download the ninth file from
 legacygames_url=https://cdn.legacygames.com/LegacyGamesLauncher/legacy-games-launcher-setup-1.10.0-x64-full.exe
 
 # Set the path to save the ninth file to
-legacygames_file=~/Downloads/NonSteamLaunchersInstallation/legacy-games-launcher-setup-1.10.0-x64-full.exe
+legacygames_file=${logged_in_home}/Downloads/NonSteamLaunchersInstallation/legacy-games-launcher-setup-1.10.0-x64-full.exe
 
 # Set the URL to download the tenth file from
 humblegames_url=https://www.humblebundle.com/app/download
 
 # Set the path to save the tenth file to
-humblegames_file=~/Downloads/NonSteamLaunchersInstallation/Humble-App-Setup-1.1.8+411.exe
+humblegames_file=${logged_in_home}/Downloads/NonSteamLaunchersInstallation/Humble-App-Setup-1.1.8+411.exe
 
 # Set the URL to download the eleventh file from
 indiegala_url=https://content.indiegalacdn.com/common/IGClientSetup.exe
 
 # Set the path to save the eleventh file to
-indiegala_file=~/Downloads/NonSteamLaunchersInstallation/IGClientSetup.exe
+indiegala_file=${logged_in_home}/Downloads/NonSteamLaunchersInstallation/IGClientSetup.exe
 
 # Set the URL to download the twelfth file from
 rockstar_url=https://gamedownloads.rockstargames.com/public/installer/Rockstar-Games-Launcher.exe
 
 # Set the path to save the twelfth file to
-rockstar_file=~/Downloads/NonSteamLaunchersInstallation/Rockstar-Games-Launcher.exe
+rockstar_file=${logged_in_home}/Downloads/NonSteamLaunchersInstallation/Rockstar-Games-Launcher.exe
 
 # Set the URL to download the Glyph Launcher file from
 glyph_url=https://glyph.dyn.triongames.com/glyph/live/GlyphInstall.exe
 
 # Set the path to save the Glyph Launcher to
-glyph_file=~/Downloads/NonSteamLaunchersInstallation/GlyphInstall.exe
+glyph_file=${logged_in_home}/Downloads/NonSteamLaunchersInstallation/GlyphInstall.exe
 
 # Set the URL to download the Minecraft Launcher file from
 minecraft_url=https://aka.ms/minecraftClientWindows
 
 # Set the path to save the Minecraft Launcher to
-minecraft_file=~/Downloads/NonSteamLaunchersInstallation/MinecraftInstaller.msi
+minecraft_file=${logged_in_home}/Downloads/NonSteamLaunchersInstallation/MinecraftInstaller.msi
 
 # Set the URL to download the Playstation Launcher file from
 psplus_url=https://download-psplus.playstation.com/downloads/psplus/pc/latest
 
 # Set the path to save the Playstation Launcher to
-psplus_file=~/Downloads/NonSteamLaunchersInstallation/PlayStationPlus-12.2.0.exe
+psplus_file=${logged_in_home}/Downloads/NonSteamLaunchersInstallation/PlayStationPlus-12.2.0.exe
 
 # Set the URL to download the Playstation Launcher file from
 dmm_url=https://apidgp-gameplayer.games.dmm.com/archive/latest?app=dgp5win
 
 # Set the path to save the Playstation Launcher to
-dmm_file=~/Downloads/NonSteamLaunchersInstallation/DMMGamePlayer-Setup-5.2.16.exe
+dmm_file=${logged_in_home}/Downloads/NonSteamLaunchersInstallation/DMMGamePlayer-Setup-5.2.16.exe
 
 echo "20"
 echo "# Creating files & folders"
@@ -1632,10 +1632,10 @@ if [[ $options == *"GOG Galaxy"* ]]; then
 
     # Find the GalaxyInstaller_XXXXX folder and copy it to C:\Downloads
     galaxy_installer_folder=$(find . -maxdepth 1 -type d -name "GalaxyInstaller_*" | head -n1)
-    cp -r "$galaxy_installer_folder" ~/Downloads/NonSteamLaunchersInstallation/
+    cp -r "$galaxy_installer_folder" ${logged_in_home}/Downloads/NonSteamLaunchersInstallation/
 
     # Navigate to the C:\Downloads\GalaxyInstaller_XXXXX folder
-    cd ~/Downloads/NonSteamLaunchersInstallation/"$(basename $galaxy_installer_folder)"
+    cd ${logged_in_home}/Downloads/NonSteamLaunchersInstallation/"$(basename $galaxy_installer_folder)"
 
     # Run GalaxySetup.exe with the /VERYSILENT and /NORESTART options
     echo "Running GalaxySetup.exe with the /VERYSILENT and /NORESTART options"
@@ -1739,12 +1739,12 @@ if [[ $options == *"Origin"* ]]; then
     # Download version.dll file
     if [ ! -f "${logged_in_home}/Downloads/NonSteamLaunchersInstallation/version.dll" ]; then
         echo "Downloading version.dll file"
-        wget https://github.com/p0358/Fuck_off_EA_App/releases/download/v2/version.dll -O ~/Downloads/NonSteamLaunchersInstallation/version.dll
+        wget https://github.com/p0358/Fuck_off_EA_App/releases/download/v2/version.dll -O ${logged_in_home}/Downloads/NonSteamLaunchersInstallation/version.dll
     fi
 
     # Move version.dll file to desired location
     echo "Moving version.dll file to desired location"
-    mv ~/Downloads/NonSteamLaunchersInstallation/version.dll "${logged_in_home}/.local/share/Steam/steamapps/compatdata/$appid/pfx/drive_c/Program Files (x86)/Origin/"
+    mv ${logged_in_home}/Downloads/NonSteamLaunchersInstallation/version.dll "${logged_in_home}/.local/share/Steam/steamapps/compatdata/$appid/pfx/drive_c/Program Files (x86)/Origin/"
 
     # Wait for the ORIGIN file to finish running
     wait
@@ -2339,7 +2339,7 @@ fi
 wait
 
 # Delete NonSteamLaunchersInstallation subfolder in Downloads folder
-rm -rf "$install_dir"
+rm -rf "$download_dir"
 
     echo "100"
     echo "# Installation Complete - Steam will now restart. Your launchers will be in your library!...Food for thought...do Jedis use Force Compatability?"
@@ -2628,9 +2628,6 @@ if [ ${#custom_websites[@]} -gt 0 ]; then
     done
 fi
 
-# Set the download directory
-download_dir=~/Downloads/NonSteamLaunchersInstallation
-
 # Create the download directory if it doesn't exist
 mkdir -p "$download_dir"
 
@@ -2638,14 +2635,14 @@ mkdir -p "$download_dir"
 python_version=$(python -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')
 
 # Create a directory for the vdf module
-mkdir -p "$download_dir/lib/python$python_version/site-packages/vdf"
+mkdir -p "${download_dir}/lib/python${python_version}/site-packages/vdf"
 
 # Download the vdf module from the GitHub repository
 download_url="https://github.com/moraroy/NonSteamLaunchers-On-Steam-Deck/raw/main/Modules/vdf/__init__.py"
-wget -P "$download_dir/lib/python$python_version/site-packages/vdf" "$download_url"
+wget -P "${download_dir}/lib/python${python_version}/site-packages/vdf" "$download_url"
 
 # Set the PYTHONPATH environment variable
-export PYTHONPATH="$download_dir/lib/python$python_version/site-packages/:$PYTHONPATH"
+export PYTHONPATH="${download_dir}/lib/python${python_version}/site-packages/:$PYTHONPATH"
 
 # Set the default Steam directory
 steam_dir="${logged_in_home}/.local/share/Steam"
@@ -3144,4 +3141,4 @@ if os.path.exists(os.path.join(compatdata_dir, 'NonSteamLaunchers')):
 
 # TODO: might be better to relocate temp files to `/tmp` or even use `mktemp -d` since `rm -rf` is potentially dangerous without the `-i` flag
 # Delete NonSteamLaunchersInstallation subfolder in Downloads folder
-rm -rf "$install_dir"
+rm -rf "$download_dir"


### PR DESCRIPTION
**NOTE**
This is a WIP meant to flag what's being done behind the scenes. Currently untested so it'd be a good idea to not approve the merge until you've ran it on your end. I'll be doing the same locally and update the PR when I've tested it.

@moraroy Please leave comments on individual TODOs / proposed changes with yea/nay and I'll honor your requests.

- use $PATH bash shebang
- capture exit code from pipes
- locally removed `.shellcheckrc`  and hardcoded `# shellcheck disable=SC____` to pinpoint language server errors
- environment variables to get actual user calling script ($HOME can be `/home/root` if called via `sudo`)
- ~~parameterize working directory~~ technically already existed, just 1000+ lines down — moved to top of the script and replaced hardcoded filepaths
- added a bunch of inline TODOs
- add error handling for killing steam by process id (pid)
- removed unnecessary newlines
- fixed indents on various code blocks
- tidied nested python script per pep8 (e.g., newlines between functions)
- set script as executable (`chmod +x`)