### PR TITLE
Added EA App NSLGameScanner Support & Refactored Slightly

### DIFF
--- a/NSLGameScanner.py
+++ b/NSLGameScanner.py
@@ -318,8 +318,8 @@ for shortcut in shortcuts['shortcuts'].values():
             if game_id is not None:
                 print(f"Got game ID from SteamGridDB: {game_id}")
                 # Download and apply artwork
-                getSGBDArt(game_id, app_id)
-                addCompatToolMapping(app_id)
+                get_sgdb_art(game_id, app_id)
+                add_compat_tool(app_id)
                 new_shortcuts_added = True
 	
 # Print the existing shortcuts

--- a/NonSteamLaunchers.sh
+++ b/NonSteamLaunchers.sh
@@ -2382,11 +2382,15 @@ if [[ -f "$eaapp_path1" ]]; then
     eaappshortcutdirectory="\"$eaapp_path1\""
     eaapplaunchoptions="STEAM_COMPAT_DATA_PATH=\"${logged_in_home}/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/\" %command%"
     eaappstartingdir="\"$(dirname "$eaapp_path1")\""
+	echo "export ea_app_launcher=NonSteamLaunchers" >> ${logged_in_home}/.config/systemd/user/env_vars
+    echo "EA App Launcher found at path 1"
 elif [[ -f "$eaapp_path2" ]]; then
     # EA App Launcher is installed at path 2
     eaappshortcutdirectory="\"$eaapp_path2\""
     eaapplaunchoptions="STEAM_COMPAT_DATA_PATH=\"${logged_in_home}/.local/share/Steam/steamapps/compatdata/TheEAappLauncher/\" %command%"
     eaappstartingdir="\"$(dirname "$eaapp_path2")\""
+	echo "export ea_app_launcher=TheEAappLauncher" >> ${logged_in_home}/.config/systemd/user/env_vars
+    echo "EA App Launcher found at path 2"
 fi
 
 if [[ -f "$amazongames_path1" ]]; then


### PR DESCRIPTION
Added support for the EA App, it works entirely based on the registry entries created when installing apps from the EA App - pretty similar to Ubisoft Connect.

Also refactored a bunch of code, extracting out the artwork and compatibility methods and only saving shortcut.vdf and config.vdf changes at the very end of each run. This has fixed the proton setting that was previously broken.

Known Issues:
- When games are uninstalled from the EA App, the entry we're using isn't removed from the registry. Meaning that game will continue to have a shortcut added even though it isn't installed.
- Sometimes special characters are included in the registry display name, I've not figured out a way to strip them out. This leads to entries in steam with titles like "Peggle\xae" and "Plants vs. Zombies\x2122".