### PR TITLE
Duplicate Ubisoft Connect Entry made by NSLGameScanner.py

### DIFF
--- a/NSLGameScanner.py
+++ b/NSLGameScanner.py
@@ -838,7 +838,7 @@ if not os.path.exists(registry_file_path):
     print("Battle.net game data not found. Skipping Battle.net Games Scanner.")
 else:
     game_dict = getBnetGameInfo(registry_file_path)
-    if game_dict is None or 'unknown':
+    if game_dict is None:
         # Skip the rest of the Battle.net scanner
         pass
     else:
@@ -851,7 +851,10 @@ else:
             if game == "Overwatch":
                 game = "Overwatch 2"
 
-            if game_info['flavor']:
+            if game_info['flavor'] == "unknown":
+                pass
+
+            elif game_info['flavor']:
                 launch_options = f"STEAM_COMPAT_DATA_PATH=\"{logged_in_home}/.local/share/Steam/steamapps/compatdata/{bnet_launcher}/\" %command% \"battlenet://{game_info['flavor']}\""
                 exe_path = f"\"{logged_in_home}/.local/share/Steam/steamapps/compatdata/{bnet_launcher}/pfx/drive_c/Program Files (x86)/Battle.net/Battle.net.exe\" --exec=\"launch {game_info['flavor']}\""
                 start_dir = f"\"{logged_in_home}/.local/share/Steam/steamapps/compatdata/{bnet_launcher}/pfx/drive_c/Program Files (x86)/Battle.net/\""

--- a/NSLGameScanner.py
+++ b/NSLGameScanner.py
@@ -838,7 +838,7 @@ if not os.path.exists(registry_file_path):
     print("Battle.net game data not found. Skipping Battle.net Games Scanner.")
 else:
     game_dict = getBnetGameInfo(registry_file_path)
-    if game_dict is None:
+    if game_dict is None or 'unknown':
         # Skip the rest of the Battle.net scanner
         pass
     else:


### PR DESCRIPTION
I noticed that I had two Ubisoft Connect entries every time I installed NonSteamLaunchers on my Steam Deck. I found out that it was the Battle Net scanner portion adding an 'unknown' game titled Ubisoft Connect as a duplicate entry. I ultimately found a file that was being identified. "C:/Program Files (x86)/Ubisoft/Ubisoft Game Launcher/_retail_/.flavor.info" and the "Flavor inferred was : unknown". Then it would say No exact match found. Using game ID of the first result: Ubisoft Connect (Program): 5270094.  It would subsequently add all of the Battle.net information for the launch of this game - that's what lead me to the Battle.net scanner failing and leading to this. The launch parameter would be --exec=\"launch unknown\". The Launch options would be %command% \"battlenet://unknown\""

It looked like you were already working on a possible overhaul during my quick review of various issues open. Not sure if this is helpful but it fixed my duplicate entry problem.

Cheers.