### PR TITLE
Fix itch.io launcher name

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ Supported Stores 🛍
 - GOG Galaxy ✔️
 - Humble Games Collection ✔️
 - IndieGala ✔️
-- Itch.io ✔️
+- itch.io ✔️
 - Legacy Games ✔️
 - Rockstar Games Launcher ✔️
 - Ubisoft Connect ✔️


### PR DESCRIPTION
Was listed as "Itch.io" in the supported launchers section. It will only be installed with the name "itch.io" (case sensitive). I only tried it with "Itch.io" and only found out through browsing the source code that it's supposed to be "itch.io".