### PR TITLE
Fix for ProtonUp-Qt installs of GE-Proton

### DIFF
--- a/NSLGameScanner.py
+++ b/NSLGameScanner.py
@@ -2942,7 +2942,7 @@ def fetch_and_parse_csv():
     # Try local UMU database first
     try:
         dir_path = f"{logged_in_home}/.steam/root/compatibilitytools.d"
-        pattern = re.compile(r"(UMU|GE)-Proton-(\d+(?:\.\d+)*)(?:-(\d+(?:\.\d+)*))?")
+        pattern = re.compile(r"(UMU|GE)-Proton-?(\d+(?:\.\d+)*)(?:-(\d+(?:\.\d+)*))?")
 
         def parse_version(m):
             main, sub = m.groups()[1:]


### PR DESCRIPTION
Make the dash between proton & major version optional because:
    ProtonUp-Qt installs to GE-ProtonXX-YY not GE-Proton-XX-YY