### PR TITLE
Parameterize EA App & itch.io launcher paths; fix Plarium uninstall path bug

### DIFF
--- a/NonSteamLaunchers.sh
+++ b/NonSteamLaunchers.sh
@@ -80,6 +80,13 @@ nsl_download() {
     fi
 }
 
+# Find a launcher's exe when its install path includes a version folder
+resolve_launcher_path() {
+    local search_dir="$1"
+    local filename="$2"
+    find "$search_dir" -iname "$filename" 2>/dev/null | head -n1
+}
+
 # Delete only paths inside known NSL locations. Refuses empty/"/"/$HOME and any
 # path outside the allowlist so a bad variable expansion can't wipe unrelated data.
 # Honours NSL_DRY_RUN.
@@ -559,9 +566,15 @@ else
 fi
 
 # Game Launchers
-
-# TODO: parameterize hard-coded client versions (cf. 'app-26.1.9')
 # Set the paths to the launcher executables
+
+# Resolved dynamically (version-numbered install path)
+eaapp_path1=$(resolve_launcher_path "${logged_in_home}/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/pfx/drive_c/Program Files/Electronic Arts/EA Desktop/" "EALauncher.exe")
+eaapp_path2=$(resolve_launcher_path "${logged_in_home}/.local/share/Steam/steamapps/compatdata/TheEAappLauncher/pfx/drive_c/Program Files/Electronic Arts/EA Desktop/" "EALauncher.exe")
+itchio_path1=$(resolve_launcher_path "${logged_in_home}/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/pfx/drive_c/users/steamuser/AppData/Local/itch/" "itch.exe")
+itchio_path2=$(resolve_launcher_path "${logged_in_home}/.local/share/Steam/steamapps/compatdata/itchioLauncher/pfx/drive_c/users/steamuser/AppData/Local/itch/" "itch.exe")
+
+# Resolved statically (non-version-numbered install path)
 epic_games_launcher_path1="${logged_in_home}/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/pfx/drive_c/Program Files/Epic Games/Launcher/Portal/Binaries/Win64/EpicGamesLauncher.exe"
 epic_games_launcher_path2="${logged_in_home}/.local/share/Steam/steamapps/compatdata/EpicGamesLauncher/pfx/drive_c/Program Files/Epic Games/Launcher/Portal/Binaries/Win64/EpicGamesLauncher.exe"
 gog_galaxy_path1="${logged_in_home}/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/pfx/drive_c/Program Files (x86)/GOG Galaxy/GalaxyClient.exe"
@@ -570,12 +583,8 @@ uplay_path1="${logged_in_home}/.local/share/Steam/steamapps/compatdata/NonSteamL
 uplay_path2="${logged_in_home}/.local/share/Steam/steamapps/compatdata/UplayLauncher/pfx/drive_c/Program Files (x86)/Ubisoft/Ubisoft Game Launcher/upc.exe"
 battlenet_path1="${logged_in_home}/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/pfx/drive_c/Program Files (x86)/Battle.net/Battle.net Launcher.exe"
 battlenet_path2="${logged_in_home}/.local/share/Steam/steamapps/compatdata/Battle.netLauncher/pfx/drive_c/Program Files (x86)/Battle.net/Battle.net Launcher.exe"
-eaapp_path1="${logged_in_home}/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/pfx/drive_c/Program Files/Electronic Arts/EA Desktop/13.735.2.6250/EA Desktop/EALauncher.exe"
-eaapp_path2="${logged_in_home}/.local/share/Steam/steamapps/compatdata/TheEAappLauncher/pfx/drive_c/Program Files/Electronic Arts/EA Desktop/13.735.2.6250/EA Desktop/EALauncher.exe"
 amazongames_path1="${logged_in_home}/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/pfx/drive_c/users/steamuser/AppData/Local/Amazon Games/App/Amazon Games.exe"
 amazongames_path2="${logged_in_home}/.local/share/Steam/steamapps/compatdata/AmazonGamesLauncher/pfx/drive_c/users/steamuser/AppData/Local/Amazon Games/App/Amazon Games.exe"
-itchio_path1="${logged_in_home}/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/pfx/drive_c/users/steamuser/AppData/Local/itch/app-26.13.0/itch.exe"
-itchio_path2="${logged_in_home}/.local/share/Steam/steamapps/compatdata/itchioLauncher/pfx/drive_c/users/steamuser/AppData/Local/itch/app-26.13.0/itch.exe"
 legacygames_path1="${logged_in_home}/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/pfx/drive_c/Program Files/Legacy Games/Legacy Games Launcher/Legacy Games Launcher.exe"
 legacygames_path2="${logged_in_home}/.local/share/Steam/steamapps/compatdata/LegacyGamesLauncher/pfx/drive_c/Program Files/Legacy Games/Legacy Games Launcher/Legacy Games Launcher.exe"
 humblegames_path1="${logged_in_home}/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/pfx/drive_c/Program Files/Humble App/Humble App.exe"
@@ -2149,7 +2158,7 @@ process_uninstall_options() {
                 sed -i '' "${logged_in_home}/.config/systemd/user/env_vars"
             elif [[ -d "${logged_in_home}/.local/share/Steam/steamapps/compatdata/PlariumLauncher" ]]; then
                 handle_uninstall_plarium "PlariumLauncher"
-                uninstall_launcher "$uninstall_options" "Plarium Play" "$eaapp_path1" "$eaapp_path2" "plarium" "plarium"
+                uninstall_launcher "$uninstall_options" "Plarium Play" "$plarium_path1" "$plarium_path2" "plarium" "plarium"
                 sed -i '' "${logged_in_home}/.config/systemd/user/env_vars"
             fi
         fi
@@ -3854,6 +3863,12 @@ check_and_write() {
     fi
 }
 
+
+# Resolved dynamically (version-numbered install path - must run after install_launcher)
+eaapp_path1=$(resolve_launcher_path "${logged_in_home}/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/pfx/drive_c/Program Files/Electronic Arts/EA Desktop/" "EALauncher.exe")
+eaapp_path2=$(resolve_launcher_path "${logged_in_home}/.local/share/Steam/steamapps/compatdata/TheEAappLauncher/pfx/drive_c/Program Files/Electronic Arts/EA Desktop/" "EALauncher.exe")
+itchio_path1=$(resolve_launcher_path "${logged_in_home}/.local/share/Steam/steamapps/compatdata/NonSteamLaunchers/pfx/drive_c/users/steamuser/AppData/Local/itch/" "itch.exe")
+itchio_path2=$(resolve_launcher_path "${logged_in_home}/.local/share/Steam/steamapps/compatdata/itchioLauncher/pfx/drive_c/users/steamuser/AppData/Local/itch/" "itch.exe")
 
 check_and_write "epic" "$epic_games_launcher_path1" "$epic_games_launcher_path2" "NonSteamLaunchers" "EpicGamesLauncher" "-opengl" "epic_games_launcher"
 check_and_write "gog" "$gog_galaxy_path1" "$gog_galaxy_path2" "NonSteamLaunchers" "GogGalaxyLauncher" "" "gog_galaxy_launcher"


### PR DESCRIPTION
# Summary
I opened this PR to fix two issues in NonSteamLaunchers.sh related to launcher path detection: hardcoded, version-pinned install paths for EA App and itch.io that break on app updates, and a copy-paste bug that could cause Plarium Play to be skipped during uninstall.

**Note:** While working on this change, I discovered that the Itch.io launcher is also failing to install. After removing the `--silent` flag from the install command and manually clicking through the installer, Itch.io was successfully installed, detected, and added to my Steam Library, confirming that this change works when Itch.io is installed. I chose not to include the flag removal change in this PR because it would require manual user intervention to complete the install without the `--silent` flag, and it seems like the goal of this script is to handle installation in the background in a more headless fashion.

## Problem
EA App and itch.io both embed a version number in their install path (e.g. EA Desktop/13.x.x.x/, itch/app-26.x.x/). These were hardcoded, so once either app auto-updates past the pinned version, check_and_write silently fails to find the executable. There is no error, just a quietly broken shortcut creation, install detection, and uninstall handling.

Separately, the "Uninstall Plarium Play" handler had a copy-paste leftover referencing `eaapp_path1`/`eaapp_path2` instead of `plarium_path1`/`plarium_path2`, which could cause Plarium Play to be skipped during uninstall depending on which prefix it's installed in.

## Changes

- Added resolve_launcher_path(), a small helper that resolves a launcher's executable via `find()` instead of a fixed path. Called for EA App and itch.io in two places:
  1. Early, alongside the other launcher path assignments, so CheckInstallations and the uninstall flow still correctly detect existing installs.
  2. Again immediately before their respective check_and_write calls, so a launcher installed earlier in the same run (first-time install) is still picked up, since bash evaluates command substitution at assignment time, not at use time.

- Fixed the Plarium Play uninstall handler to reference the correct `plarium_path1`/`plarium_path2` variables.

## Testing

- Verified on a Steam Deck with EA App already installed under a newer version folder than the previously hardcoded one. Shortcut creation and env var writing (ea_app_launcher) now succeed.
- Verified fresh-install ordering: resolve_launcher_path re-runs after install_launcher, so a first-time EA App install in the same script run is correctly detected before check_and_write.
- Confirmed no other references to `eaapp_path1`/`eaapp_path2` or `itchio_path1`/`itchio_path2` exist earlier in the script than the initial resolution point (checked via grep across the full file).

## AI Usage Disclosure
I used Claude Sonnet 5 Medium during the troubleshooting process, script changes, and to assist with commit and PR messaging. I manually tested the changes made in my feature branch against the v4.2.91 main branch release on my own Steam Deck and confirmed that the EA App and Itch.io (without the `--silent` flag) launchers were successfully installed, detected by the script, and added to my Steam Library.